### PR TITLE
Update RateLimiter protocol

### DIFF
--- a/aqute/ratelimiter.py
+++ b/aqute/ratelimiter.py
@@ -2,13 +2,15 @@ import asyncio
 import logging
 from collections import defaultdict, deque
 from time import perf_counter
-from typing import Deque, Dict, Protocol, Union
+from typing import Deque, Dict, Optional, Protocol, Union
+
+from aqute.task import AquteTask
 
 logger = logging.getLogger("aqute.ratelimiter")
 
 
 class RateLimiter(Protocol):
-    async def acquire(self, name: str = "") -> None:
+    async def acquire(self, name: str = "", task: Optional[AquteTask] = None) -> None:
         """Shoild block inside this method if needed"""
 
 
@@ -54,7 +56,7 @@ class TokenBucketRateLimiter:
         self._tokens = min(self._bucket_capacity, self._tokens + tokens_to_add)
         self._last_fill = current_time
 
-    async def acquire(self, name: str = "") -> None:
+    async def acquire(self, name: str = "", task: Optional[AquteTask] = None) -> None:
         """
         Acquires permission to proceed based on the rate limits set.
 
@@ -97,7 +99,7 @@ class SlidingRateLimiter:
         self._timestamps: Deque = deque(maxlen=max_rate)
         self._lock = asyncio.Lock()
 
-    async def acquire(self, name: str = "") -> None:
+    async def acquire(self, name: str = "", task: Optional[AquteTask] = None) -> None:
         """
         Acquires permission to proceed based on the rate limits set.
 
@@ -146,7 +148,7 @@ class PerWorkerRateLimiter:
             lambda: TokenBucketRateLimiter(max_rate, time_period)
         )
 
-    async def acquire(self, name: str = "") -> None:
+    async def acquire(self, name: str = "", task: Optional[AquteTask] = None) -> None:
         """
         Acquires a token for a particular worker, identified by `name`,
         to proceed with an action.

--- a/aqute/worker.py
+++ b/aqute/worker.py
@@ -39,7 +39,7 @@ class Worker(Generic[TData, TResult]):
 
     async def handle_task(self, task: AquteTask[TData, TResult]) -> None:
         if self.rate_limiter:
-            await self.rate_limiter.acquire(self.name)
+            await self.rate_limiter.acquire(name=self.name, task=task)
         try:
             task.result = await asyncio.wait_for(
                 self.handle_coro(task.data), timeout=self.task_timeout_seconds
@@ -179,7 +179,7 @@ class Foreman(Generic[TData, TResult]):
         self.out_queue = asyncio.Queue()
         self._workers = [
             Worker(
-                name=f"{i}",
+                name=f"worker_{i}",
                 handle_coro=self._handle_coro,
                 input_q=self.in_queue,
                 output_q=self.out_queue,

--- a/tests/rate_limiter/test_protocol.py
+++ b/tests/rate_limiter/test_protocol.py
@@ -1,0 +1,31 @@
+from typing import Optional
+
+import pytest
+
+from aqute import Aqute, AquteTask
+from aqute.ratelimiter import RateLimiter
+
+
+class StoringRateLimiter(RateLimiter):
+    def __init__(self) -> None:
+        self.store = []
+
+    async def acquire(
+        self, name: str = "", task: Optional[AquteTask] = None, **kwargs
+    ) -> None:
+        self.store.append((name, task.data, task.task_id, kwargs))
+
+
+@pytest.mark.asyncio
+async def test_rate_limiter_protocol():
+    answer = [
+        ("worker_0", 1, "0", {}),
+        ("worker_0", 2, "1", {}),
+    ]
+
+    async def handler(i: int) -> str:
+        return f"Result {i}"
+
+    aq = Aqute(handler, 1, rate_limiter=StoringRateLimiter())
+    await aq.apply_to_all([1, 2])
+    assert aq._rate_limiter.store == answer


### PR DESCRIPTION
- Expand `RateLimiter` protocol so `AquteTask` data can be used inside it.
- Rename internal worker name template 

Closes #18