### PR TITLE
perf: reduce scheduling overhead and add opt-in submission batching

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Aqute
 
-**A**sync **QU**eue **T**ask **E**ngine processes coroutine calls with a worker pool,
-optional rate limits, and retries. It requires Python 3.11 or newer and has no
-runtime dependencies. It runs in one process; pending work and results do not
-survive process termination.
+**A**sync **QU**eue **T**ask **E**ngine is a performance-oriented asyncio task engine
+with configurable concurrency, queue limits, retries, and rate limiting.
+It requires Python 3.11 or newer and has no runtime dependencies. It runs in one
+process; pending work and results do not survive process termination.
 
 ## Quickstart
 
@@ -22,6 +22,11 @@ handler, error handling, and `asyncio.run()`. `process_all()` returns an awaited
 list in input order. `iter_results()` yields terminal results in completion order.
 Both accept synchronous and asynchronous input. Inspect each task's `error` or
 `success`; `None` can be a valid result.
+
+Both helpers accept `submission_batch_size` (default `1`). Larger batches can
+improve throughput for small tasks at the cost of result latency. The default
+preserves per-item cooperative yielding. Handlers still receive one item per call;
+configure worker concurrency and queue limits separately.
 
 ## Documentation and examples
 

--- a/aqute/engine.py
+++ b/aqute/engine.py
@@ -269,7 +269,10 @@ class Aqute(Generic[TData, TResult]):
         self._load_changed.set()
 
     async def iter_results(
-        self, tasks_data: Iterable[TData] | AsyncIterable[TData]
+        self,
+        tasks_data: Iterable[TData] | AsyncIterable[TData],
+        *,
+        submission_batch_size: int = 1,
     ) -> AsyncGenerator[AquteTask[TData, TResult]]:
         """
         Asynchronously processes each task from the provided iterable.
@@ -281,14 +284,27 @@ class Aqute(Generic[TData, TResult]):
 
         Args:
             tasks_data: Iterable containing data for each task.
+            submission_batch_size: Positive number of inputs to admit between
+                cooperative yields. Defaults to 1. Larger values can improve
+                throughput at the cost of result latency. Queue backpressure
+                and asynchronous input can yield sooner. Handlers still receive
+                one item each; this does not bound otherwise unlimited queues.
+                Batching can be slower when small input queues fill frequently.
 
         Returns:
             An async iterator yielding results as `AquteTask` objects.
+
+        Raises:
+            ValueError: If submission_batch_size is not a positive integer.
+                Validation occurs when iteration starts, before consuming input.
         """
+        if not isinstance(submission_batch_size, int) or submission_batch_size < 1:
+            raise ValueError("submission_batch_size must be a positive integer")
         async with self:
             load = self.start()
             producer = asyncio.create_task(
-                self._produce_tasks(tasks_data), name="aqute-producer"
+                self._produce_tasks(tasks_data, submission_batch_size),
+                name="aqute-producer",
             )
             changed = self._results_changed
             producer.add_done_callback(lambda _: changed.set())
@@ -319,14 +335,20 @@ class Aqute(Generic[TData, TResult]):
                         raise
 
     async def _produce_tasks(
-        self, tasks_data: Iterable[TData] | AsyncIterable[TData]
+        self,
+        tasks_data: Iterable[TData] | AsyncIterable[TData],
+        submission_batch_size: int,
     ) -> None:
+        remaining = submission_batch_size
         if isinstance(tasks_data, AsyncIterable):
             source = aiter(tasks_data)
             try:
                 async for data in source:
                     await self.add_task(data)
-                    await asyncio.sleep(0)
+                    remaining -= 1
+                    if remaining == 0:
+                        remaining = submission_batch_size
+                        await asyncio.sleep(0)
             finally:
                 if isinstance(source, AsyncGenerator):
                     await source.aclose()
@@ -335,14 +357,20 @@ class Aqute(Generic[TData, TResult]):
             try:
                 for data in source:
                     await self.add_task(data)
-                    await asyncio.sleep(0)
+                    remaining -= 1
+                    if remaining == 0:
+                        remaining = submission_batch_size
+                        await asyncio.sleep(0)
             finally:
                 if isinstance(source, Generator):
                     source.close()
         self.finish_submitting()
 
     async def process_all(
-        self, tasks_data: Iterable[TData] | AsyncIterable[TData]
+        self,
+        tasks_data: Iterable[TData] | AsyncIterable[TData],
+        *,
+        submission_batch_size: int = 1,
     ) -> list[AquteTask[TData, TResult]]:
         """
         Asynchronously processes all tasks from the provided iterable.
@@ -353,12 +381,19 @@ class Aqute(Generic[TData, TResult]):
 
         Args:
             tasks_data: Iterable containing data items for the tasks.
+            submission_batch_size: Positive number of inputs to admit between
+                cooperative yields; see iter_results(). Defaults to 1.
 
         Returns:
             A list of `AquteTask` objects with results, ordered as in the
             input iterable.
+
+        Raises:
+            ValueError: If submission_batch_size is not a positive integer.
         """
-        async with contextlib.aclosing(self.iter_results(tasks_data)) as results:
+        async with contextlib.aclosing(
+            self.iter_results(tasks_data, submission_batch_size=submission_batch_size)
+        ) as results:
             result = [task async for task in results]
         return sorted(result, key=lambda task: int(task.task_id))
 

--- a/aqute/engine.py
+++ b/aqute/engine.py
@@ -115,6 +115,7 @@ class Aqute(Generic[TData, TResult]):
 
         self._all_tasks_added = False
         self._load_changed = asyncio.Event()
+        self._results_changed = asyncio.Event()
 
         self._specific_errors_to_retry = specific_errors_to_retry
         self._errors_to_not_retry = errors_to_not_retry
@@ -155,9 +156,12 @@ class Aqute(Generic[TData, TResult]):
         """
         logger.debug("Starting aqute")
         if self.aiotask_of_run_load is None:
+            self._results_changed = asyncio.Event()
             self.aiotask_of_run_load = asyncio.create_task(
                 self._run_load(), name="aqute-load"
             )
+            changed = self._results_changed
+            self.aiotask_of_run_load.add_done_callback(lambda _: changed.set())
 
         return self.aiotask_of_run_load
 
@@ -286,6 +290,8 @@ class Aqute(Generic[TData, TResult]):
             producer = asyncio.create_task(
                 self._produce_tasks(tasks_data), name="aqute-producer"
             )
+            changed = self._results_changed
+            producer.add_done_callback(lambda _: changed.set())
             exposed = 0
             try:
                 while not producer.done() or exposed < self._added_tasks_count:
@@ -295,23 +301,10 @@ class Aqute(Generic[TData, TResult]):
                         exposed += 1
                         yield self.result_queue.get_nowait()
                         continue
-                    result = asyncio.create_task(self.result_queue.get())
-                    try:
-                        waiting = (result, load)
-                        if not producer.done():
-                            waiting = (*waiting, producer)
-                        await asyncio.wait(waiting, return_when=asyncio.FIRST_COMPLETED)
-                        if producer.done():
-                            await producer
-                        if result.done():
-                            exposed += 1
-                            yield result.result()
-                        elif load.done():
-                            await load
-                    finally:
-                        result.cancel()
-                        with contextlib.suppress(asyncio.CancelledError):
-                            await result
+                    if load.done():
+                        await load
+                    changed.clear()
+                    await changed.wait()
                 await producer
                 await load
             finally:
@@ -385,19 +378,16 @@ class Aqute(Generic[TData, TResult]):
         load = self.aiotask_of_run_load
         if load is None:
             raise AquteError("Cannot get task result without started load")
-        result = asyncio.create_task(self.result_queue.get())
-        try:
-            await asyncio.wait((result, load), return_when=asyncio.FIRST_COMPLETED)
-            if result.done():
-                return result.result()
-            if load.cancelled():
-                raise AquteError("Load was cancelled; call stop first")
-            await load
-            raise AquteError("Load finished without another task result")
-        finally:
-            result.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
-                await result
+        changed = self._results_changed
+        while self.result_queue.empty():
+            if load.done():
+                if load.cancelled():
+                    raise AquteError("Load was cancelled; call stop first")
+                await load
+                raise AquteError("Load finished without another task result")
+            changed.clear()
+            await changed.wait()
+        return self.result_queue.get_nowait()
 
     def drain_results(self) -> list[AquteTask[TData, TResult]]:
         """
@@ -499,8 +489,10 @@ class Aqute(Generic[TData, TResult]):
         await self._put_task_to_result(handled_task)
 
         logger.debug(
-            f"Finished task {task_id} "
-            f"{self._added_tasks_count, self._finished_tasks_count}"
+            "Finished task %s (%s, %s)",
+            task_id,
+            self._added_tasks_count,
+            self._finished_tasks_count,
         )
 
     def _check_failed_tasks_limit(self) -> None:
@@ -532,6 +524,7 @@ class Aqute(Generic[TData, TResult]):
     async def _put_task_to_result(self, task: AquteTask[TData, TResult]) -> None:
         self._finished_tasks_count += 1
         await self.result_queue.put(task)
+        self._results_changed.set()
 
     async def __aenter__(self) -> Self:
         self.start()

--- a/aqute/worker.py
+++ b/aqute/worker.py
@@ -37,6 +37,7 @@ class Worker(Generic[TData, TResult]):
         retry_filter: Callable[[AquteTask[TData, TResult]], bool] | None = None,
         retry_delay: Callable[[int, Exception], float] | None = None,
         _counters: _WorkerCounters | None = None,
+        _results_changed: asyncio.Event | None = None,
     ):
         self.handle_coro = handle_coro
         self.input_q = input_q
@@ -48,13 +49,14 @@ class Worker(Generic[TData, TResult]):
         self._retry_filter = retry_filter
         self._retry_delay = retry_delay
         self._counters = _counters if _counters is not None else _WorkerCounters()
+        self._results_changed = _results_changed
 
     async def run(self) -> None:
         while True:
             task = await self.input_q.get()
             self._counters.running += 1
             try:
-                logger.debug(f"Worker {self.name} got task {task.task_id}")
+                logger.debug("Worker %s got task %s", self.name, task.task_id)
                 if task.data is END_MARKER:
                     return
                 await self.handle_task(task)
@@ -89,6 +91,8 @@ class Worker(Generic[TData, TResult]):
         else:
             self._counters.failed += 1
         await self.output_q.put(task)
+        if self._results_changed is not None:
+            self._results_changed.set()
 
     async def _handle_attempt(
         self, task: AquteTask[TData, TResult], *, is_retry: bool
@@ -98,10 +102,15 @@ class Worker(Generic[TData, TResult]):
         try:
             if self.task_timeout_seconds is not None and self.task_timeout_seconds <= 0:
                 raise TimeoutError
-            async with asyncio.timeout(self.task_timeout_seconds):
+            if self.task_timeout_seconds is None:
                 if is_retry:
                     self._counters.retries += 1
                 task.result = await self.handle_coro(task.data)
+            else:
+                async with asyncio.timeout(self.task_timeout_seconds):
+                    if is_retry:
+                        self._counters.retries += 1
+                    task.result = await self.handle_coro(task.data)
         except TimeoutError:
             logger.warning(
                 f"Worker {self.name} on {task.task_id} timed out after "
@@ -188,6 +197,8 @@ class Foreman(Generic[TData, TResult]):
             self._worker_run = asyncio.create_task(
                 self._run_workers(), name="aqute-workers"
             )
+            changed = self._results_changed
+            self._worker_run.add_done_callback(lambda _: changed.set())
 
     async def add_task(self, task: AquteTask[TData, TResult]) -> None:
         """
@@ -222,23 +233,17 @@ class Foreman(Generic[TData, TResult]):
         Returns:
             AquteTask: The processed task from the queue.
         """
-        if not self.out_queue.empty():
-            return self.out_queue.get_nowait()
-        if self._worker_run is None:
-            return await self.out_queue.get()
-        result = asyncio.create_task(self.out_queue.get())
-        try:
-            await asyncio.wait(
-                (result, self._worker_run), return_when=asyncio.FIRST_COMPLETED
-            )
-            if result.done():
-                return result.result()
-            await self._worker_run
-            raise RuntimeError("Workers finished without another result")
-        finally:
-            result.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
-                await result
+        # Keep this run's queue and notification if finalize/stop resets the pool.
+        queue, changed, run = self.out_queue, self._results_changed, self._worker_run
+        if run is None:
+            return await queue.get()
+        while queue.empty():
+            if run.done():
+                await run
+                raise RuntimeError("Workers finished without another result")
+            changed.clear()
+            await changed.wait()
+        return queue.get_nowait()
 
     async def finalize(self) -> None:
         """
@@ -283,6 +288,7 @@ class Foreman(Generic[TData, TResult]):
         logger.debug("Resetting workers")
         self.in_queue = self._create_task_queue(size=self._input_task_queue_size)
         self.out_queue = asyncio.Queue(maxsize=self._output_task_queue_size)
+        self._results_changed = asyncio.Event()
         self._workers = [
             Worker(
                 name=f"worker_{i}",
@@ -294,6 +300,7 @@ class Foreman(Generic[TData, TResult]):
                 retry_filter=self._retry_filter,
                 retry_delay=self._retry_delay,
                 _counters=self._counters,
+                _results_changed=self._results_changed,
             )
             for i in range(self._workers_count)
         ]

--- a/aqute/worker.py
+++ b/aqute/worker.py
@@ -222,6 +222,11 @@ class Foreman(Generic[TData, TResult]):
                 raise RuntimeError("Workers finished before the task could be queued")
             await admission
         finally:
+            # Some Python 3.14 releases retain this task on a pending supervisor.
+            # https://github.com/python/cpython/issues/152569
+            discard = getattr(asyncio, "future_discard_from_awaited_by", None)
+            if discard is not None:
+                discard(run, asyncio.current_task())
             admission.cancel()
             with contextlib.suppress(asyncio.CancelledError):
                 await admission

--- a/scripts/benchmark.py
+++ b/scripts/benchmark.py
@@ -58,7 +58,7 @@ class Work:
         assert self.active == 0 and self.peak_active <= self.workers
         assert self.peak_ahead <= 4 * self.workers + 3
 
-    async def run(self, mode: str):
+    async def run(self, mode: str, batch_size: int | None):
         engine = Aqute(
             self.handle,
             self.workers,
@@ -66,7 +66,12 @@ class Work:
             result_queue=asyncio.Queue(self.workers),
         )
         if mode == "helper":
-            async with aclosing(engine.iter_results(self.source())) as results:
+            options = (
+                {} if batch_size is None else {"submission_batch_size": batch_size}
+            )
+            async with aclosing(
+                engine.iter_results(self.source(), **options)
+            ) as results:
                 async for task in results:
                     self.consume(task)
         else:
@@ -90,19 +95,20 @@ class Work:
 async def sample(args):
     delay = {"immediate": None, "yield": 0, "sleep1": 0.001, "sleep10": 0.01}[args.case]
     warm = Work(min(args.count, 128), args.workers, delay)
-    await warm.run(args.mode)
+    await warm.run(args.mode, args.batch_size)
     warm.verify()
     del warm
     gc.collect()
     work = Work(args.count, args.workers, delay)
     cpu, wall = time.process_time(), time.perf_counter()
-    await work.run(args.mode)
+    await work.run(args.mode, args.batch_size)
     seconds, cpu_seconds = time.perf_counter() - wall, time.process_time() - cpu
     work.verify()
     return {
         "python": platform.python_version(),
         "source": aqute.__file__,
         "mode": args.mode,
+        "submission_batch_size": args.batch_size,
         "case": args.case,
         "workers": args.workers,
         "items": args.count,
@@ -126,9 +132,19 @@ def main():
     )
     parser.add_argument("--workers", type=int, default=32)
     parser.add_argument("--count", type=int, default=50000)
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        help="Helper inputs between yields; omit to use the library default.",
+    )
     args = parser.parse_args()
     if args.count < 1 or args.workers < 1:
         parser.error("--count and --workers must be positive")
+    if args.batch_size is not None:
+        if args.batch_size < 1:
+            parser.error("--batch-size must be positive")
+        if args.mode != "helper":
+            parser.error("--batch-size applies only to --mode helper")
     sys.stdout.write(json.dumps(asyncio.run(sample(args))) + "\n")
 
 

--- a/scripts/benchmark.py
+++ b/scripts/benchmark.py
@@ -1,0 +1,136 @@
+"""Measure Aqute scheduling with bounded queues and verified results.
+
+Run from the repository root with PYTHONPATH=. uv run --locked python
+scripts/benchmark.py. Use an isolated interpreter and PYTHONPATH pointing to a
+source snapshot when comparing revisions. Imports and warmup are not timed.
+"""
+
+import argparse
+import asyncio
+import gc
+import json
+import platform
+import sys
+import time
+from contextlib import aclosing
+
+import aqute
+from aqute import Aqute
+
+
+class Work:
+    def __init__(self, count: int, workers: int, delay: float | None):
+        self.count = count
+        self.workers = workers
+        self.delay = delay
+        # Allocate the correctness audit before starting the measurement.
+        self.seen = bytearray(count)
+        self.calls = self.returned = self.active = self.peak_active = 0
+        self.produced = self.peak_ahead = 0
+
+    def source(self):
+        for value in range(self.count):
+            self.produced += 1
+            self.peak_ahead = max(self.peak_ahead, self.produced - self.returned)
+            yield value
+
+    async def handle(self, value: int) -> int:
+        self.calls += 1
+        self.active += 1
+        self.peak_active = max(self.peak_active, self.active)
+        try:
+            if self.delay is not None:
+                await asyncio.sleep(self.delay)
+            return value
+        finally:
+            self.active -= 1
+
+    def consume(self, task):
+        assert task.success and task.error is None
+        value = task.result
+        assert isinstance(value, int) and 0 <= value < self.count
+        assert task.data == value and not self.seen[value]
+        self.seen[value] = 1
+        self.returned += 1
+
+    def verify(self):
+        assert self.calls == self.returned == self.count and all(self.seen)
+        assert self.active == 0 and self.peak_active <= self.workers
+        assert self.peak_ahead <= 4 * self.workers + 3
+
+    async def run(self, mode: str):
+        engine = Aqute(
+            self.handle,
+            self.workers,
+            input_task_queue_size=self.workers,
+            result_queue=asyncio.Queue(self.workers),
+        )
+        if mode == "helper":
+            async with aclosing(engine.iter_results(self.source())) as results:
+                async for task in results:
+                    self.consume(task)
+        else:
+            async with engine:
+
+                async def produce():
+                    for value in self.source():
+                        await engine.add_task(value)
+                    engine.finish_submitting()
+
+                async def consume():
+                    for _ in range(self.count):
+                        self.consume(await engine.get_result())
+
+                async with asyncio.TaskGroup() as group:
+                    group.create_task(produce())
+                    group.create_task(consume())
+                await engine.finish()
+
+
+async def sample(args):
+    delay = {"immediate": None, "yield": 0, "sleep1": 0.001, "sleep10": 0.01}[args.case]
+    warm = Work(min(args.count, 128), args.workers, delay)
+    await warm.run(args.mode)
+    warm.verify()
+    del warm
+    gc.collect()
+    work = Work(args.count, args.workers, delay)
+    cpu, wall = time.process_time(), time.perf_counter()
+    await work.run(args.mode)
+    seconds, cpu_seconds = time.perf_counter() - wall, time.process_time() - cpu
+    work.verify()
+    return {
+        "python": platform.python_version(),
+        "source": aqute.__file__,
+        "mode": args.mode,
+        "case": args.case,
+        "workers": args.workers,
+        "items": args.count,
+        "seconds": seconds,
+        "cpu_seconds": cpu_seconds,
+        "items_per_second": args.count / seconds,
+        "cpu_us_per_item": cpu_seconds * 1e6 / args.count,
+        "peak_active": work.peak_active,
+        "peak_generated_ahead": work.peak_ahead,
+        "results": work.returned,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--mode", choices=["helper", "manual"], default="helper")
+    parser.add_argument(
+        "--case",
+        choices=["immediate", "yield", "sleep1", "sleep10"],
+        default="immediate",
+    )
+    parser.add_argument("--workers", type=int, default=32)
+    parser.add_argument("--count", type=int, default=50000)
+    args = parser.parse_args()
+    if args.count < 1 or args.workers < 1:
+        parser.error("--count and --workers must be positive")
+    sys.stdout.write(json.dumps(asyncio.run(sample(args))) + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/aqute/test_errors.py
+++ b/tests/aqute/test_errors.py
@@ -81,31 +81,45 @@ async def test_too_many_failed_tasks_error(retry_count: int):
 
 
 @pytest.mark.asyncio
-async def test_too_many_failed_tasks_error_with_helper_each():
+@pytest.mark.parametrize("batch_size", [1, 32])
+@pytest.mark.parametrize("input_queue_size", [0, 1])
+async def test_too_many_failed_tasks_error_with_helper_each(
+    batch_size, input_queue_size
+):
     aqute = Aqute(
         workers_count=2,
         handle_coro=failing_handler,
         retry_count=0,
         total_failed_tasks_limit=1,
+        input_task_queue_size=input_queue_size,
     )
 
-    with pytest.raises(AquteTooManyTasksFailedError) as exc:
-        async for _ in aqute.iter_results(range(1, 6)):
-            pass
+    async with asyncio.timeout(1):
+        with pytest.raises(AquteTooManyTasksFailedError) as exc:
+            async for _ in aqute.iter_results(
+                range(1, 6), submission_batch_size=batch_size
+            ):
+                pass
     assert "limit reached: 1" in str(exc.value)
 
 
 @pytest.mark.asyncio
-async def test_too_many_failed_tasks_error_with_helper_all():
+@pytest.mark.parametrize("batch_size", [1, 32])
+@pytest.mark.parametrize("input_queue_size", [0, 1])
+async def test_too_many_failed_tasks_error_with_helper_all(
+    batch_size, input_queue_size
+):
     aqute = Aqute(
         workers_count=2,
         handle_coro=failing_handler,
         retry_count=0,
         total_failed_tasks_limit=1,
+        input_task_queue_size=input_queue_size,
     )
 
-    with pytest.raises(AquteTooManyTasksFailedError) as exc:
-        await aqute.process_all(range(1, 6))
+    async with asyncio.timeout(1):
+        with pytest.raises(AquteTooManyTasksFailedError) as exc:
+            await aqute.process_all(range(1, 6), submission_batch_size=batch_size)
     assert "limit reached: 1" in str(exc.value)
 
 

--- a/tests/aqute/test_lifecycle.py
+++ b/tests/aqute/test_lifecycle.py
@@ -22,6 +22,56 @@ async def test_wait_after_all_results_were_consumed():
 
 
 @pytest.mark.asyncio
+async def test_cancelled_result_wait_leaves_processing_available():
+    """Cancelling a reader must not cancel work or consume its eventual result."""
+    release = asyncio.Event()
+
+    async def handler(value: int) -> int:
+        await release.wait()
+        return value
+
+    async with Aqute(handler, 1, result_queue=asyncio.Queue(1)) as engine:
+        await engine.add_task(7)
+        reader = asyncio.create_task(engine.get_result())
+        await asyncio.sleep(0)
+        reader.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await reader
+        release.set()
+        async with asyncio.timeout(1):
+            assert (await engine.get_result()).result == 7
+            await engine.finish()
+        assert engine.drain_results() == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("stop", [False, True])
+async def test_waiting_result_reader_exits_with_load_and_engine_can_restart(stop):
+    """An empty load's completion or stop must unblock its reader before reuse."""
+    engine = Aqute(echo, 1)
+    engine.start()
+    reader = asyncio.create_task(engine.get_result())
+    try:
+        await asyncio.sleep(0)
+        async with asyncio.timeout(1):
+            if stop:
+                await engine.stop()
+            else:
+                await engine.finish()
+            with pytest.raises(
+                AquteError, match=r"cancelled|without another task result"
+            ):
+                await reader
+            await engine.stop()
+            assert (await engine.process_all([7]))[0].result == 7
+    finally:
+        reader.cancel()
+        with contextlib.suppress(asyncio.CancelledError, AquteError):
+            await reader
+        await engine.stop()
+
+
+@pytest.mark.asyncio
 async def test_wait_after_starting_empty_load():
     async with Aqute(echo, 1) as engine:
         await asyncio.sleep(0)

--- a/tests/aqute/test_streaming.py
+++ b/tests/aqute/test_streaming.py
@@ -13,9 +13,77 @@ async def echo(value: int) -> int:
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("collect", [False, True])
+@pytest.mark.parametrize("batch_size", [0, -1, 1.5])
+async def test_invalid_submission_batch_does_not_consume_input(collect, batch_size):
+    """Invalid batching must fail without consuming input or preventing reuse."""
+    consumed = []
+
+    def source():
+        consumed.append(1)
+        yield 1
+
+    engine = Aqute(echo, 1)
+    with pytest.raises(ValueError, match="submission_batch_size"):
+        if collect:
+            await engine.process_all(source(), submission_batch_size=batch_size)
+        else:
+            async with contextlib.aclosing(
+                engine.iter_results(source(), submission_batch_size=batch_size)
+            ) as results:
+                await anext(results)
+    assert consumed == []
+    assert (await engine.process_all([2]))[0].result == 2
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("collect", [False, True])
+@pytest.mark.parametrize("asynchronous", [False, True])
+@pytest.mark.parametrize("batch_size", [None, 4])
+async def test_submission_batch_gives_ready_coroutines_a_turn(
+    collect, asynchronous, batch_size
+):
+    """Even unbounded submission must give ready coroutines a turn after a batch."""
+    produced = 0
+    observer = None
+
+    async def observe():
+        return produced
+
+    def source():
+        nonlocal produced, observer
+        for value in range(9):
+            produced += 1
+            if observer is None:
+                observer = asyncio.create_task(observe())
+            yield value
+
+    async def async_source():
+        for value in source():
+            yield value
+
+    items = async_source() if asynchronous else source()
+    options = {} if batch_size is None else {"submission_batch_size": batch_size}
+    engine = Aqute(echo, 2)
+    async with asyncio.timeout(1):
+        if collect:
+            results = await engine.process_all(items, **options)
+        else:
+            results = [result async for result in engine.iter_results(items, **options)]
+        assert observer is not None
+        assert await observer == (1 if batch_size is None else batch_size)
+    assert [
+        result.result for result in sorted(results, key=lambda task: task.data)
+    ] == list(range(9))
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("collect", [False, True])
 @pytest.mark.parametrize("asynchronous", [False, True])
 @pytest.mark.parametrize("values", [[], [1, 2]])
-async def test_helpers_complete_with_bounded_queues(collect, asynchronous, values):
+@pytest.mark.parametrize("batch_size", [1, 4, 32])
+async def test_helpers_complete_with_bounded_queues(
+    collect, asynchronous, values, batch_size
+):
     async def source():
         for value in values:
             yield value
@@ -30,15 +98,21 @@ async def test_helpers_complete_with_bounded_queues(collect, asynchronous, value
     )
     async with asyncio.timeout(1):
         if collect:
-            results = await engine.process_all(items)
+            results = await engine.process_all(items, submission_batch_size=batch_size)
         else:
-            results = [result async for result in engine.iter_results(items)]
+            results = [
+                result
+                async for result in engine.iter_results(
+                    items, submission_batch_size=batch_size
+                )
+            ]
     assert [result.result for result in results] == values
     assert all(result.success for result in results)
 
 
 @pytest.mark.asyncio
-async def test_first_result_precedes_async_source_exhaustion():
+@pytest.mark.parametrize("batch_size", [1, 32])
+async def test_first_result_precedes_async_source_exhaustion(batch_size):
     release = asyncio.Event()
 
     async def source():
@@ -47,7 +121,9 @@ async def test_first_result_precedes_async_source_exhaustion():
         yield 2
 
     engine = Aqute(echo, 1)
-    async with contextlib.aclosing(engine.iter_results(source())) as results:
+    async with contextlib.aclosing(
+        engine.iter_results(source(), submission_batch_size=batch_size)
+    ) as results:
         async with asyncio.timeout(1):
             assert (await anext(results)).result == 1
             release.set()
@@ -57,7 +133,8 @@ async def test_first_result_precedes_async_source_exhaustion():
 
 
 @pytest.mark.asyncio
-async def test_iterator_yields_in_completion_order():
+@pytest.mark.parametrize("batch_size", [1, 32])
+async def test_iterator_yields_in_completion_order(batch_size):
     release = asyncio.Event()
 
     async def handler(value: int) -> int:
@@ -66,7 +143,9 @@ async def test_iterator_yields_in_completion_order():
         return value
 
     engine = Aqute(handler, 2, input_task_queue_size=1)
-    async with contextlib.aclosing(engine.iter_results([1, 2])) as results:
+    async with contextlib.aclosing(
+        engine.iter_results([1, 2], submission_batch_size=batch_size)
+    ) as results:
         async with asyncio.timeout(1):
             assert (await anext(results)).result == 2
             release.set()
@@ -74,8 +153,8 @@ async def test_iterator_yields_in_completion_order():
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("manual", [False, True])
-async def test_slow_consumption_bounds_production_and_handlers(manual):
+@pytest.mark.parametrize(("manual", "batch_size"), [(True, 1), (False, 1), (False, 32)])
+async def test_slow_consumption_bounds_production_and_handlers(manual, batch_size):
     # I + 2R + W + 3 includes a producer item and the currently yielded result.
     bound = 1 + 2 * 1 + 2 + 3
     produced = 0
@@ -126,7 +205,9 @@ async def test_slow_consumption_bounds_production_and_handlers(manual):
                     with contextlib.suppress(asyncio.CancelledError):
                         await producer
         else:
-            async with contextlib.aclosing(engine.iter_results(source())) as stream:
+            async with contextlib.aclosing(
+                engine.iter_results(source(), submission_batch_size=batch_size)
+            ) as stream:
                 first = await anext(stream)
                 with pytest.raises(TimeoutError):
                     async with asyncio.timeout(0.05):
@@ -142,7 +223,10 @@ async def test_slow_consumption_bounds_production_and_handlers(manual):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("priority", [False, True])
-async def test_retries_complete_with_slow_consumption_and_bounded_queues(priority):
+@pytest.mark.parametrize("batch_size", [1, 32])
+async def test_retries_complete_with_slow_consumption_and_bounded_queues(
+    priority, batch_size
+):
     attempts = Counter()
 
     async def handler(value: int) -> int:
@@ -161,7 +245,9 @@ async def test_retries_complete_with_slow_consumption_and_bounded_queues(priorit
     )
     async with asyncio.timeout(2):
         results = []
-        async for result in engine.iter_results(range(20)):
+        async for result in engine.iter_results(
+            range(20), submission_batch_size=batch_size
+        ):
             results.append(result)
             await asyncio.sleep(0.001)
     assert all(result.success for result in results)
@@ -172,7 +258,8 @@ async def test_retries_complete_with_slow_consumption_and_bounded_queues(priorit
 
 
 @pytest.mark.asyncio
-async def test_source_failure_cancels_active_handler():
+@pytest.mark.parametrize("batch_size", [1, 32])
+async def test_source_failure_cancels_active_handler(batch_size):
     started = asyncio.Event()
     cleaned = asyncio.Event()
 
@@ -192,13 +279,14 @@ async def test_source_failure_cancels_active_handler():
     engine = Aqute(handler, 1, input_task_queue_size=1)
     async with asyncio.timeout(1):
         with pytest.raises(ValueError, match="source failed"):
-            await engine.process_all(source())
+            await engine.process_all(source(), submission_batch_size=batch_size)
     assert cleaned.is_set()
 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("asynchronous", [False, True])
-async def test_iterator_close_cleans_source_and_handler(asynchronous):
+@pytest.mark.parametrize("batch_size", [1, 32])
+async def test_iterator_close_cleans_source_and_handler(asynchronous, batch_size):
     started = asyncio.Event()
     cleaned = asyncio.Event()
     source_closed = asyncio.Event()
@@ -228,7 +316,9 @@ async def test_iterator_close_cleans_source_and_handler(asynchronous):
     engine = Aqute(handler, 1, input_task_queue_size=1, result_queue=asyncio.Queue(1))
     items = async_source() if asynchronous else source()
     async with asyncio.timeout(1):
-        async with contextlib.aclosing(engine.iter_results(items)) as results:
+        async with contextlib.aclosing(
+            engine.iter_results(items, submission_batch_size=batch_size)
+        ) as results:
             assert (await anext(results)).result == 0
             await started.wait()
     assert cleaned.is_set()
@@ -261,7 +351,8 @@ async def test_cancelling_collection_cleans_waiting_source():
 
 
 @pytest.mark.asyncio
-async def test_drain_retained_results_before_reusing_helper():
+@pytest.mark.parametrize("batch_size", [1, 32])
+async def test_drain_retained_results_before_reusing_helper(batch_size):
     completed = asyncio.Event()
     handled = []
 
@@ -273,7 +364,9 @@ async def test_drain_retained_results_before_reusing_helper():
 
     engine = Aqute(handler, 2)
     async with asyncio.timeout(1):
-        async with contextlib.aclosing(engine.iter_results([1, 2, 3])) as results:
+        async with contextlib.aclosing(
+            engine.iter_results([1, 2, 3], submission_batch_size=batch_size)
+        ) as results:
             first = await anext(results)
             await completed.wait()
             # Waiting for the public run drains completed work into retained results.

--- a/tests/worker/test_foreman.py
+++ b/tests/worker/test_foreman.py
@@ -1,4 +1,5 @@
 import asyncio
+import contextlib
 
 import pytest
 
@@ -57,6 +58,35 @@ async def test_foreman_finalize():
     await foreman.add_task(AquteTask(data="reused", task_id="3"))
     assert (await foreman.get_handled_task()).result == "handled-reused"
     await foreman.finalize()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("stop", [False, True])
+async def test_waiting_reader_exits_when_pool_resets(stop):
+    """Stopping or finalizing must release an empty reader and permit reuse."""
+    foreman = Foreman(simple_handler, 1)
+    foreman.start()
+    reader = asyncio.create_task(foreman.get_handled_task())
+    try:
+        await asyncio.sleep(0)
+        async with asyncio.timeout(1):
+            if stop:
+                await foreman.stop()
+                with pytest.raises(asyncio.CancelledError):
+                    await reader
+            else:
+                await foreman.finalize()
+                with pytest.raises(RuntimeError, match="without another result"):
+                    await reader
+            foreman.start()
+            await foreman.add_task(AquteTask("reused", "1"))
+            assert (await foreman.get_handled_task()).result == "handled-reused"
+            await foreman.finalize()
+    finally:
+        reader.cancel()
+        with contextlib.suppress(asyncio.CancelledError, RuntimeError):
+            await reader
+        await foreman.stop()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Small coroutine jobs paid for temporary result-wait tasks and a producer yield after every input. Use result notifications, skip disabled timeout contexts, and add opt-in `submission_batch_size` to `iter_results` and `process_all`. The default remains 1; each handler still receives one item.

Keep bounded buffering and existing cancellation/error handling. Add cleanup for retained admission-task references on affected Python 3.14 versions. The README now describes the performance focus and the batching latency tradeoff.

### Measurements

Five interleaved runs on CPython 3.14.6 with standard asyncio, 32 configured workers, and input/result queue capacities of 32. Median completed items/s:

| Workload | Aqute default | Aqute batch 32 | aiojobs 1.4.0 |
| --- | ---: | ---: | ---: |
| Immediate return | 99,958 | 219,249 | 237,829 |
| `sleep(0)` | 93,132 | 223,379 | 205,332 |
| TCP echo | 50,785 | 83,317 | 83,344 |

Immediate and yielding runs use 50,000 items; TCP uses 10,000 64-byte exchanges over 32 reused loopback connections. Immediate-return handlers measure scheduling overhead. These are selected local comparisons with different adapter contracts and buffering; they do not establish universal superiority.

Batching increases result latency: immediate-result p99 rises from 36.5 to 436.9 microseconds. The included benchmark CLI supports helper/manual comparisons. Full diagnostics, 2,098 samples, 15 CPU profiles, and review dispositions are attached to Zhournal task `aqute-scheduling-performance-v1`.

### Validation

- `make check`: 245 tests pass on Python 3.11; Ruff, ty, coverage, and strict documentation build pass.
- `make build` and installed-wheel smoke checks on Python 3.11 and 3.14 pass.
- Earlier performance qualification covers Python 3.11/3.14, 32/128 workers, bounded and slow consumers, and lifecycle/error behavior.
- Scheduling source bytes match the measured and independently reviewed candidate after rebasing onto the rate-limiter fix in #36. The benchmarked workloads do not configure a rate limiter.
- No `docs/` files or temporary state documents are included.
