### PR TITLE
fix: randomize rate limiter modulation phase

### DIFF
--- a/aqute/ratelimiter.py
+++ b/aqute/ratelimiter.py
@@ -187,25 +187,29 @@ class RandomizedIntervalRateLimiter:
         lower_upper_fluctuation: float = 0.005,
     ):
         """
-        Initializes the RandomizedIntervalRateLimiter with specified parameters,
-        defining the rate limiting behavior with randomized intervals.
-        Sleep interval duratation is randomized, but rate limiting is assured for
-        max_rate in time_period. Can be used to emulate more "human-like" behavior.
+        Limits grants to max_rate in each rolling time_period, with bounded jitter.
+
+        Each grant waits for quota, then for an additional randomized delay,
+        including at startup and after idle. Independent random phases reduce
+        counter-linked regularity; they do not model human behavior or guarantee
+        detection avoidance. Additional waits can reduce sustained throughput.
 
         Args:
             max_rate: Maximum allowable actions within the time period.
             time_period (optional): Finite positive period in seconds for rate
                 measurement. Defaults to 1 second.
-            mean_target_multiplier (optional): The mean multiplier influencing
-                the average sleep duration.
-            std_dev (optional): The standard deviation for the Gaussian distribution,
-                adding randomness to the multiplier.
+            mean_target_multiplier (optional): Mean of the Gaussian input, before
+                phase scaling and bounding. This is not the mean emitted delay.
+            std_dev (optional): Standard deviation of the Gaussian input.
             lower_multiplier_bound (optional): The lower bound for the multiplier,
                 ensuring a minimum sleep duration.
             upper_multiplier_bound (optional): The upper bound for the multiplier,
-                ensuring a maximum sleep duration.
-            lower_upper_fluctuation (optional): The fluctuation margin for the
-                multiplier bounds, adding variability when bounds are reached.
+                bounding the additional delay, not quota or scheduler waits.
+            lower_upper_fluctuation (optional): Inward bound adjustment, multiplied
+                by the same absolute sine of a uniform phase as the Gaussian input.
+                Use nonnegative bounds and fluctuation with twice the fluctuation
+                no greater than the difference between upper and lower bounds.
+                Multipliers convert to seconds through time_period / max_rate.
         """
         if max_rate < 1 or not 0 < time_period < math.inf:
             raise ValueError(
@@ -221,22 +225,17 @@ class RandomizedIntervalRateLimiter:
         self._lower_bound = lower_multiplier_bound
         self._upper_bound = upper_multiplier_bound
         self._fluctuation = lower_upper_fluctuation
-        self._gen_count = 0
 
         self._request_times: deque[float] = deque(maxlen=max_rate)
         self._lock = asyncio.Lock()
 
     def _get_multiplier(self) -> float:
         """
-        Determines the sleep time multiplier. The multiplier is based on a Gaussian
-        distribution and sinusoidal oscillation, ensuring variability within the
-        predefined bounds. This method is a key component in managing the randomized
-        intervals between actions.
+        Samples one phase for the Gaussian amplitude and both effective bounds.
         """
         value = random.gauss(self._mean_mul, self._std_dev)
-        oscillation = abs(math.sin(self._gen_count))
+        oscillation = abs(math.sin(random.uniform(0.0, math.tau)))
         value = value * oscillation
-        self._gen_count += 1
 
         fluctuation = oscillation * self._fluctuation
         max_value = min(self._upper_bound - fluctuation, value)

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -33,7 +33,28 @@ Available implementations are in `aqute.ratelimiter`:
 - `TokenBucketRateLimiter` controls a shared rate, with optional bursts.
 - `SlidingRateLimiter` limits calls within a moving time window.
 - `PerWorkerRateLimiter` applies a separate token bucket to each worker.
-- `RandomizedIntervalRateLimiter` randomizes intervals around the configured rate.
+- `RandomizedIntervalRateLimiter` adds bounded random delays after rolling-cap waits.
+
+`RandomizedIntervalRateLimiter(N, T)` grants at most `N` acquisitions in each
+rolling `T` seconds. Each acquisition waits for quota, then for its full additional
+random delay. This delay also applies at startup, with sparse traffic and after
+idle. Quota waits and event-loop scheduling can increase the total wait beyond the
+configured jitter bounds. Sustained throughput can be below `N / T`.
+
+`mean_target_multiplier` and `std_dev` describe the Gaussian input, before scaling
+and bounding. They do not specify the mean or deviation of emitted intervals.
+An independent uniform phase supplies an absolute sine scale for each acquisition.
+The same scale multiplies the Gaussian input and `lower_upper_fluctuation`, which
+moves both multiplier bounds inward. The resulting bounded multiplier converts
+to seconds through `T / N`. Use nonnegative bounds and fluctuation, with
+`2 * lower_upper_fluctuation <= upper_multiplier_bound - lower_multiplier_bound`.
+The lower bound remains an additional minimum delay even when quota is available.
+
+Independent phases replace the previous request-counter ordering while retaining
+coupled amplitude and bound modulation. Seeded sequences and startup delays change.
+This reduces conspicuous counter-linked regularity; it does not model human
+behavior or guarantee avoidance of detection. Removing the old ordering can also
+reduce throughput, even when the overall delay distribution is similar.
 
 A custom limiter implements `async acquire(name="", task=None)`. It must propagate
 cancellation. CPU-heavy or blocking work in a handler blocks the event loop;

--- a/tests/aqute/test_ratelimiter.py
+++ b/tests/aqute/test_ratelimiter.py
@@ -32,7 +32,7 @@ async def test_with_ratelimiter(rl_name: str):
     limiters = {
         "Sliding": SlidingRateLimiter(5, 0.2),
         "Token Bucket": TokenBucketRateLimiter(5, 0.2),
-        # This parameters should ensure passing of this tests
+        # These parameters keep randomized completion within the shared budget.
         "Randomized": RandomizedIntervalRateLimiter(
             5, 0.2, mean_target_multiplier=0.3, upper_multiplier_bound=0.5
         ),
@@ -41,8 +41,14 @@ async def test_with_ratelimiter(rl_name: str):
         "Per Worker": PerWorkerRateLimiter(1, 0.4),
     }
     rate_limiter = limiters[rl_name]
+    handler_starts = []
+
+    async def timed_handler(i: int) -> str:
+        handler_starts.append(perf_counter())
+        return await non_failing_handler(i)
+
     aqute = Aqute(
-        workers_count=10, handle_coro=non_failing_handler, rate_limiter=rate_limiter
+        workers_count=10, handle_coro=timed_handler, rate_limiter=rate_limiter
     )
 
     start = perf_counter()
@@ -50,3 +56,9 @@ async def test_with_ratelimiter(rl_name: str):
     elapsed_time = perf_counter() - start
 
     assert 0.4 < elapsed_time < 0.5
+    if rl_name == "Randomized":
+        # The rolling cap must hold at the actual handler boundary too.
+        assert all(
+            handler_starts[i] - handler_starts[i - 5] >= 0.2
+            for i in range(5, len(handler_starts))
+        )

--- a/tests/rate_limiter/test_configuration.py
+++ b/tests/rate_limiter/test_configuration.py
@@ -24,3 +24,10 @@ def test_invalid_time_period(limiter_class, time_period):
     """Reject invalid periods before the limiter can accept work."""
     with pytest.raises(ValueError):
         limiter_class(1, time_period)
+
+
+@pytest.mark.parametrize("max_rate", [0, -1])
+def test_randomized_rejects_nonpositive_rate(max_rate):
+    """Invalid rates must fail before randomized acquisition can start."""
+    with pytest.raises(ValueError):
+        RandomizedIntervalRateLimiter(max_rate)

--- a/tests/rate_limiter/test_randomized_interval.py
+++ b/tests/rate_limiter/test_randomized_interval.py
@@ -1,4 +1,5 @@
 import asyncio
+import random
 from time import perf_counter
 
 import pytest
@@ -14,13 +15,16 @@ async def test_basic_rate_limiting():
     We should wait at least time period at next request after max rate, but no more,
     than time period + optimal sleep time * multiplier upper bound * 2
     """
-    limiter = RandomizedIntervalRateLimiter(2, 0.1)
+    max_rate, time_period, upper_bound = 2, 0.1, 1.1
+    limiter = RandomizedIntervalRateLimiter(
+        max_rate, time_period, upper_multiplier_bound=upper_bound
+    )
     start = perf_counter()
     await limiter.acquire()
     await limiter.acquire()
     await limiter.acquire()
     elapsed_time = perf_counter() - start
-    top_cap = 0.1 + limiter._optimal_sleep * limiter._upper_bound * 2
+    top_cap = time_period + time_period / max_rate * upper_bound * 2
     assert check_value_in_interval(elapsed_time, 0.1, top_cap)
 
 
@@ -29,7 +33,10 @@ async def test_simultaneous_rate_limiting():
     """
     Same but with multiple coroutines
     """
-    limiter = RandomizedIntervalRateLimiter(2, 0.1)
+    max_rate, time_period, upper_bound = 2, 0.1, 1.1
+    limiter = RandomizedIntervalRateLimiter(
+        max_rate, time_period, upper_multiplier_bound=upper_bound
+    )
 
     async def simulator(rl: RandomizedIntervalRateLimiter):
         await rl.acquire()
@@ -37,7 +44,7 @@ async def test_simultaneous_rate_limiting():
     start = perf_counter()
     await asyncio.gather(*[simulator(limiter) for _ in range(3)])
     elapsed_time = perf_counter() - start
-    top_cap = 0.1 + limiter._optimal_sleep * limiter._upper_bound * 2
+    top_cap = time_period + time_period / max_rate * upper_bound * 2
     assert check_value_in_interval(elapsed_time, 0.1, top_cap)
 
 
@@ -64,3 +71,31 @@ async def test_all_intervals():
             failed.append((i, i - max_rate, delta))
 
     assert not failed
+
+
+@pytest.mark.asyncio
+async def test_startup_has_randomized_delay():
+    """A fresh limiter must not always grant immediately because its index is zero."""
+    state = random.getstate()
+    random.seed(1)
+    try:
+        limiter = RandomizedIntervalRateLimiter(1, 0.1)
+        start = perf_counter()
+        await limiter.acquire()
+        assert perf_counter() - start >= 0.01
+    finally:
+        random.setstate(state)
+
+
+@pytest.mark.asyncio
+async def test_minimum_delay_with_available_quota_and_after_idle():
+    """Available quota must not bypass the additional configured minimum delay."""
+    max_rate, time_period, lower_bound = 2, 0.1, 0.3
+    limiter = RandomizedIntervalRateLimiter(
+        max_rate, time_period, lower_multiplier_bound=lower_bound
+    )
+    for pause in (0, 0, time_period * 1.1):
+        await asyncio.sleep(pause)
+        start = perf_counter()
+        await limiter.acquire()
+        assert perf_counter() - start >= time_period / max_rate * lower_bound


### PR DESCRIPTION
The randomized limiter previously tied its delay scale to the acquisition counter, creating a repeatable timing pattern. Sample an independent uniform phase for each acquisition while retaining the Gaussian input and the shared scale for amplitude and both effective bounds.

The rolling-window ceiling, lock, quota wait, full additional delay, constructor defaults and existing timing budgets remain unchanged. Seeded sequences and startup delays intentionally change. Public regressions cover startup and minimum-delay behavior; documentation explains the parameters, bounds and throughput cost.

Local verification on `5f46b8490129264cd6fa637b5f1e74836ff40995`:

- `make check`: 249 tests passed; Ruff, type checking and strict docs passed; total coverage 98.4%.
- `make build`: source distribution and wheel passed.
- `make wheel-smoke SMOKE_PYTHON=3.11`, `3.12`, `3.13`, and `3.14`: passed separately.
- Independent read-only Claude review: LGTM with minors; no blocking defect. Fresh documentation audit: verified no-op.

Actual asyncio measurements used five alternating seed pairs against baseline `4089d482066a9ec8c3bcd41c1de165f66f41f3d3`, with N=1/5/20, default/custom/positive-minimum settings, separate warmup and 270 sustained traces of at least 100 periods. Startup, batches, idle resumption and distinct sparse-arrival models were also checked. Strict rolling-cap and minimum-delay shortfalls were zero; existing completion budgets passed.

| Default setting | Sequential throughput change | Concurrent | Aqute |
| --- | ---: | ---: | ---: |
| N=5, T=0.1s | -1.336% | -1.381% | -1.453% |
| N=20, T=0.1s | -0.516% | -0.559% | -0.371% |

These are median paired changes on one Linux host. Baseline/candidate ranges do not overlap for these cases; custom-setting and N=1 changes overlap measured variation. The owner approved proceeding with this disclosed tradeoff. At N=5, default sequential counter-phase correlation fell from 0.4367 to 0.0087. Rolling-cap dependence remains. Formula-only distribution comparisons were recorded separately and are not runtime measurements.

Tracked by `task:aqute-ratelimiter-jitter-v1`, contract revision 2. No scheduling algorithm, public configuration or dependency was added.
