### PR TITLE
test: replace queue admission timing assumptions with controlled progress

### DIFF
--- a/tests/aqute/test_queue_size.py
+++ b/tests/aqute/test_queue_size.py
@@ -1,5 +1,4 @@
 import asyncio
-from time import perf_counter
 
 import pytest
 
@@ -10,131 +9,100 @@ async def run_with_queue_size(
     workers_count: int,
     input_queue_size: int,
     tasks_to_add: int,
-    sleep_time: float,
     use_priority_queue: bool = False,
-) -> list[float]:
-    async def sleep_handler(i: int) -> int:
-        await asyncio.sleep(sleep_time)
-        return i
+) -> None:
+    started: asyncio.Queue[int] = asyncio.Queue()
+    release = [asyncio.Event() for _ in range(tasks_to_add)]
+
+    async def controlled_handler(i: int) -> int:
+        started.put_nowait(i)
+        await release[i].wait()
+        return i * 2
 
     aqute = Aqute(
-        handle_coro=sleep_handler,
+        handle_coro=controlled_handler,
         workers_count=workers_count,
         input_task_queue_size=input_queue_size,
         use_priority_queue=use_priority_queue,
     )
-    add_timings = []
-    async with aqute:
-        total_start = perf_counter()
-        for i in range(tasks_to_add):
-            start = perf_counter()
-            await aqute.add_task(i)
-            add_timings.append(perf_counter() - start)
 
-        await aqute.finish()
-        total_elapsed = perf_counter() - total_start
+    async def submit(i: int, submitting: asyncio.Event) -> str:
+        submitting.set()
+        task_id = await aqute.add_task(i)
+        assert aqute.counters.pending <= input_queue_size
+        return task_id
 
-    should_take = tasks_to_add * sleep_time / workers_count
-    assert should_take <= total_elapsed < should_take + 0.03
+    # This watchdog detects stalled progress; elapsed time is not an oracle.
+    async with asyncio.timeout(5), aqute, asyncio.TaskGroup() as submissions:
+        try:
+            active = []
+            for i in range(workers_count):
+                await aqute.add_task(i)
+                active.append(await started.get())
 
-    return add_timings
+            if input_queue_size == 0:
+                # Every remaining input is admitted while all workers are held.
+                for i in range(workers_count, tasks_to_add):
+                    await aqute.add_task(i)
+                assert aqute.counters.pending == tasks_to_add - workers_count
+            else:
+                capacity = workers_count + input_queue_size
+                for i in range(workers_count, capacity):
+                    await aqute.add_task(i)
+                assert aqute.counters.pending == input_queue_size
+
+                for i in range(capacity, tasks_to_add):
+                    submitting = asyncio.Event()
+                    submission = submissions.create_task(submit(i, submitting))
+                    await submitting.wait()
+                    assert not submission.done()
+
+                    # Release one actual handler, without assuming worker order.
+                    release[active.pop(0)].set()
+                    active.append(await started.get())
+                    await submission
+                    assert aqute.counters.pending == input_queue_size
+
+            for gate in release:
+                gate.set()
+            await aqute.finish()
+            results = aqute.drain_results()
+            assert len(results) == tasks_to_add
+            assert all(task.success and task.error is None for task in results)
+            assert sorted((task.data, task.result) for task in results) == [
+                (i, i * 2) for i in range(tasks_to_add)
+            ]
+        finally:
+            for gate in release:
+                gate.set()
 
 
 @pytest.mark.asyncio
 async def test_no_queue_size():
-    add_timings = await run_with_queue_size(1, 0, 6, 0.05)
-
-    # Since there is no queue size limit, all tasks are added instantly
-    # because they do not have to wait for a slot to open up in the queue.
-    assert all([t < 0.05 for t in add_timings])
+    await run_with_queue_size(1, 0, 6)
 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("use_priority_queue", [False, True], ids=["normal", "prior"])
 async def test_queue_size_one(use_priority_queue: bool):
-    add_timings = await run_with_queue_size(1, 1, 6, 0.05, use_priority_queue)
-
-    # The first two tasks are added instantly
-    # due to the available worker and one queue slot.
-    # The remaining tasks have to wait for the worker to finish and free up the slot.
-    expected = [True, True, False, False, False, False]
-    assert [t < 0.05 for t in add_timings] == expected
+    await run_with_queue_size(1, 1, 6, use_priority_queue)
 
 
 @pytest.mark.asyncio
 async def test_queue_size_two():
-    add_timings = await run_with_queue_size(1, 2, 7, 0.05)
-
-    # The first three tasks are added instantly
-    # because of the two queue slots plus one worker.
-    # Subsequent tasks have to wait for the worker to process a task
-    # before they can be added.
-    expected = [True, True, True, False, False, False, False]
-    assert [t < 0.05 for t in add_timings] == expected
+    await run_with_queue_size(1, 2, 7)
 
 
 @pytest.mark.asyncio
 async def test_two_workers():
-    add_timings = await run_with_queue_size(2, 1, 9, 0.05)
-
-    # The first three tasks are added instantly (two workers plus one queue slot).
-    # As there are two workers, the tasks are processed faster,
-    # but due to the queue size being one,
-    # the task additions alternate between instant and waiting.
-    expected = [True, True, True, False, True, False, True, False, True]
-    assert [t < 0.05 for t in add_timings] == expected
+    await run_with_queue_size(2, 1, 9)
 
 
 @pytest.mark.asyncio
 async def test_two_workers_size_two():
-    add_timings = await run_with_queue_size(2, 2, 9, 0.05)
-
-    # 1. The first four tasks are added instantly. This is because there are two workers
-    #    and a queue size of two, which means that there's enough capacity
-    #    to handle four tasks immediately (two being processed, two in queue).
-    # 2. As tasks are being processed, the fifth task must wait for the first task
-    #    to complete because there are only two workers and the queue is full.
-    # 3. After the first task completes, the fifth task is added with 0.05 timing.
-    # 4. Second task finishes almost same time, sixth task is added to the queue
-    #    and we get instant adding time.
-    # 5. Now seventh task waits for third task to finish, and worker to free the slot.
-    # And so on...
-
-    expected = [True, True, True, True, False, True, False, True, False]
-    assert [t < 0.05 for t in add_timings] == expected
+    await run_with_queue_size(2, 2, 9)
 
 
 @pytest.mark.asyncio
 async def test_three_workers_size_two():
-    add_timings = await run_with_queue_size(3, 2, 12, 0.05)
-
-    # 1. The first five tasks are added instantly.
-    #    With three workers and a queue size of two, there's capacity for five tasks
-    #    to be added immediately (three being processed, two in queue).
-    # 2. As tasks are being processed, the sixth task must wait for the first
-    #    to complete because all three workers are busy and the queue is full.
-    # 3. After the first task completion, the sixth task is added with 0.05 timing.
-    # 4. As the second and third tasks finish almost the same time,
-    #    the seventh and eighth tasks are added instantly, because
-    #    new slots in the queue are available now.
-    # 5. This pattern continues with the ninth task waiting for the fourth task
-    #    before it can be added, as all workers are occupied again.
-    # 6. With each set of three tasks being processed,
-    #    there is a brief period where the queue is full, resulting in
-    #    every third task having to wait for the previous set to finish.
-    # And so on...
-    expected = [
-        True,
-        True,
-        True,
-        True,
-        True,
-        False,
-        True,
-        True,
-        False,
-        True,
-        True,
-        False,
-    ]
-    assert [t < 0.05 for t in add_timings] == expected
+    await run_with_queue_size(3, 2, 12)


### PR DESCRIPTION
The queue tests could fail while admission still respected the configured bound: a blocked submission can wait less than the handler’s full 50 ms sleep, and worker completions need not alternate. Replace those elapsed-time assumptions with event-controlled handlers and public checks for backpressure, resumed admission, and successful terminal results.

All seven existing worker/queue and normal/priority cases remain. Only `tests/aqute/test_queue_size.py` changes; production behavior and rate-limiter timing budgets are unchanged.

Validation on `c64979699a8e0497cb1dcc7a9b50f9b9eca5bb7f`:

- Python 3.11.15: 20 normal pytest runs and 20 coverage runs of the complete queue-test file, seven cases each, zero failures.
- Python 3.12.13, 3.13.14, and 3.14.6: all seven targeted cases passed on each version.
- `UV_PYTHON=3.11 make check`: 249 tests passed, plus Ruff, type checks, coverage generation, and strict MkDocs build.
- Independent read-only Claude review: LGTM with minors, with no unresolved findings. Fresh documentation audit: no changes needed; strict docs, formatting/lint, and 13 focused tests passed.
- Temporary public-configuration probes rejected ignored capacity and no-op processing and completed without pending asyncio tasks.

Both historical CI failure logs remain preserved. Their exact scheduler cause is unproven; repeated passing is evidence, not proof of absent flakiness.
