### PR TITLE
ci: publish Aqute documentation on GitHub Pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,54 @@
+name: Documentation
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pages-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    if: github.event_name != 'workflow_dispatch' || github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          version: "0.12.10"
+          python-version: "3.11"
+          enable-cache: true
+      - run: uv sync --locked
+      - run: make docs
+      - name: Upload Pages artifact
+        if: >-
+          github.repository == 'insomnes/aqute' && github.ref == 'refs/heads/main' &&
+          (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
+        with:
+          path: site/
+
+  deploy:
+    if: >-
+      github.repository == 'insomnes/aqute' && github.ref == 'refs/heads/main' &&
+      (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Check Pages configuration
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@368f82528645a54fb793d4d04e342629a3f51346 # v5.0.1

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ offload them to threads or processes.
 Use it for API ingestion and backfills, infrastructure automation, or independent
 remote inference and evaluation requests. Your application owns retry safety,
 checkpoints, token budgets, and provider policy. See
-[when to choose Aqute](https://github.com/insomnes/aqute/blob/main/docs/index.md#when-to-choose-aqute)
+[when to choose Aqute](https://insomnes.github.io/aqute/#when-to-choose-aqute)
 for a short comparison with plain asyncio and aiometer.
 
 ## Quickstart
@@ -39,10 +39,11 @@ configure worker concurrency and queue limits separately.
 
 ## Documentation and examples
 
-[Usage](https://github.com/insomnes/aqute/blob/main/docs/usage.md) covers bounded buffering, iterator cleanup, rate limits,
+The [documentation](https://insomnes.github.io/aqute/) includes the complete quickstart.
+[Usage](https://insomnes.github.io/aqute/usage/) covers bounded buffering, iterator cleanup, rate limits,
 retries, shutdown, counters, and deprecated method names. Full examples cover
-[streaming](https://github.com/insomnes/aqute/blob/main/examples/streaming.py), a shared [HTTP client](https://github.com/insomnes/aqute/blob/main/examples/http_client.py),
-and [service shutdown](https://github.com/insomnes/aqute/blob/main/examples/service_shutdown.py).
+[streaming](https://insomnes.github.io/aqute/streaming/), a shared [HTTP client](https://insomnes.github.io/aqute/http_client/),
+and [service shutdown](https://insomnes.github.io/aqute/service_shutdown/).
 
 The [documentation source](https://github.com/insomnes/aqute/blob/main/docs/index.md) includes code directly from these
 runnable files when built. To build and view the site locally:
@@ -65,10 +66,10 @@ uv run --locked python -m examples.quickstart
 ```
 
 `make check` runs Ruff, ty, pytest with coverage, and the strict documentation build.
-See [development](https://github.com/insomnes/aqute/blob/main/docs/development.md) for example commands and release behavior.
+See [development](https://insomnes.github.io/aqute/development/) for example commands and release behavior.
 CI tests Python 3.11 through 3.14. See [LICENSE](https://github.com/insomnes/aqute/blob/main/LICENSE).
 
 The measured coverage badge, XML, JSON, and HTML report are available in the
 `coverage-python-3.11` artifact of each successful [CI run](https://github.com/insomnes/aqute/actions/workflows/ci.yml).
 Run `make coverage` to generate the same files locally. See
-[coverage reporting](https://github.com/insomnes/aqute/blob/main/docs/development.md#coverage) for the measurement scope.
+[coverage reporting](https://insomnes.github.io/aqute/development/#coverage) for the measurement scope.

--- a/docs/development.md
+++ b/docs/development.md
@@ -32,9 +32,30 @@ tag (optional `v` prefix), builds with `uv_build`, and publishes through GitHub'
 trusted PyPI identity. See [LICENSE](https://github.com/insomnes/aqute/blob/main/LICENSE).
 
 Run commands from the repository root. `make docs` builds the site in `site/`;
-`uv run --locked mkdocs serve` provides a local preview. The documentation includes
-the actual files in `examples/`. Missing source files fail the build. No site
-deployment is configured.
+`uv run --locked mkdocs serve` provides a local preview at
+`http://127.0.0.1:8000/aqute/`. The documentation includes the actual files in
+`examples/`. Missing source files fail the build.
+
+## Documentation publication
+
+The documentation site is [insomnes.github.io/aqute](https://insomnes.github.io/aqute/).
+The [Documentation workflow](https://github.com/insomnes/aqute/actions/workflows/docs.yml)
+runs `make docs` with the locked development environment on pull requests and
+pushes to `main`. Pull requests only build the site. Successful builds from `main`
+in `insomnes/aqute` upload `site/` and deploy it through the `github-pages`
+environment. Only the deployment job receives Pages and OIDC write permissions.
+Runs for the same Git ref are serialized without cancelling an active run.
+
+Before the first deployment, a repository administrator must select **GitHub
+Actions** under **Settings > Pages > Build and deployment > Source**. Configure the
+`github-pages` environment to allow deployments only from the `main` branch.
+See GitHub's [publishing source instructions](https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site).
+
+To redeploy, open the Documentation workflow, select **Run workflow**, and choose
+`main`. Manual runs from other refs skip both jobs. The deployment job links to
+the published site. After deployment, check the homepage, navigation, example
+pages, and static assets under `/aqute/`. `make docs` verifies the local build;
+it does not verify publication.
 
 ## Coverage
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,7 +2,7 @@ site_name: Aqute
 site_url: https://insomnes.github.io/aqute/
 site_description: Async coroutine processing with bounded queues, retries, and rate limits.
 repo_url: https://github.com/insomnes/aqute
-edit_uri: blob/main/docs/
+edit_uri: edit/main/docs/
 theme: mkdocs
 nav:
   - Quickstart: index.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,8 @@
 site_name: Aqute
+site_url: https://insomnes.github.io/aqute/
 site_description: Async coroutine processing with bounded queues, retries, and rate limits.
 repo_url: https://github.com/insomnes/aqute
+edit_uri: blob/main/docs/
 theme: mkdocs
 nav:
   - Quickstart: index.md


### PR DESCRIPTION
Publish the existing MkDocs site at https://insomnes.github.io/aqute/ and link README to its usage and example pages. Pull requests build the site; only trusted main pushes or main manual runs can deploy. Pages write permissions are limited to the deployment job, with a main-only environment.

Validation on `d6d83a4f88a65353087b3e5344abaaf39df2c58c`: `make check build docs` (249 tests), actionlint, diff checks, and generated link/source/asset checks passed. Cold Claude review and documentation audit completed; the edit-link correction received LGTM. Live deployment verification follows merge.

Zhournal: `task:aqute-github-pages-docs-v1` (revision 1).
