### PR TITLE
feat!: own streaming cleanup with an async context

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,11 @@ results = await Aqute(handle, workers_count=4).process_all(range(10))
 
 See the complete runnable [quickstart](https://github.com/insomnes/aqute/blob/main/examples/quickstart.py) for imports, a
 handler, error handling, and `asyncio.run()`. `process_all()` returns an awaited
-list in input order. `iter_results()` yields terminal results in completion order.
-Both accept synchronous and asynchronous input. Inspect each task's `error` or
-`success`; `None` can be a valid result.
+list in input order. For completion-order streaming, use
+`async with engine.iter_results(items) as results` and iterate `results` inside the
+context. Context exit awaits producer and worker cleanup, including after early
+exit. Both helpers accept synchronous and asynchronous input. Inspect each task's
+`error` or `success`; `None` can be a valid result.
 
 Both helpers accept `submission_batch_size` (default `1`). Larger batches can
 improve throughput for small tasks at the cost of result latency. The default
@@ -40,7 +42,7 @@ configure worker concurrency and queue limits separately.
 ## Documentation and examples
 
 The [documentation](https://insomnes.github.io/aqute/) includes the complete quickstart.
-[Usage](https://insomnes.github.io/aqute/usage/) covers bounded buffering, iterator cleanup, rate limits,
+[Usage](https://insomnes.github.io/aqute/usage/) covers bounded buffering, streaming cleanup, rate limits,
 retries, shutdown, counters, and deprecated method names. Full examples cover
 [streaming](https://insomnes.github.io/aqute/streaming/), a shared [HTTP client](https://insomnes.github.io/aqute/http_client/),
 and [service shutdown](https://insomnes.github.io/aqute/service_shutdown/).

--- a/aqute/engine.py
+++ b/aqute/engine.py
@@ -5,6 +5,7 @@ import warnings
 from collections.abc import (
     AsyncGenerator,
     AsyncIterable,
+    AsyncIterator,
     Callable,
     Coroutine,
     Generator,
@@ -268,18 +269,24 @@ class Aqute(Generic[TData, TResult]):
         self._all_tasks_added = True
         self._load_changed.set()
 
-    async def iter_results(
+    def iter_results(
         self,
         tasks_data: Iterable[TData] | AsyncIterable[TData],
         *,
         submission_batch_size: int = 1,
-    ) -> AsyncGenerator[AquteTask[TData, TResult]]:
+    ) -> contextlib.AbstractAsyncContextManager[
+        AsyncIterator[AquteTask[TData, TResult]]
+    ]:
         """
-        Asynchronously processes each task from the provided iterable.
+        Return a context that owns a single-use, lazy result iterator.
 
         Produce input concurrently with processing and yield terminal results
         in completion order. Finite input and result queues bound buffering.
-        Close a partially consumed iterator with contextlib.aclosing.
+        Use ``async with engine.iter_results(items) as results``. First iteration
+        starts processing; context entry alone does not consume or close input.
+        Context exit awaits producer and worker cleanup, including after a break,
+        consumer exception, or cancellation. Cleanup requires cooperative sources
+        and handlers. Drain retained results before reusing the engine.
         Source exceptions propagate after cancelling owned processing.
 
         Args:
@@ -292,12 +299,22 @@ class Aqute(Generic[TData, TResult]):
                 Batching can be slower when small input queues fill frequently.
 
         Returns:
-            An async iterator yielding results as `AquteTask` objects.
+            An async context manager yielding an iterator of `AquteTask` objects.
 
         Raises:
             ValueError: If submission_batch_size is not a positive integer.
                 Validation occurs when iteration starts, before consuming input.
         """
+        return contextlib.aclosing(
+            self._iter_results(tasks_data, submission_batch_size=submission_batch_size)
+        )
+
+    async def _iter_results(
+        self,
+        tasks_data: Iterable[TData] | AsyncIterable[TData],
+        *,
+        submission_batch_size: int = 1,
+    ) -> AsyncGenerator[AquteTask[TData, TResult]]:
         if not isinstance(submission_batch_size, int) or submission_batch_size < 1:
             raise ValueError("submission_batch_size must be a positive integer")
         async with self:
@@ -391,8 +408,8 @@ class Aqute(Generic[TData, TResult]):
         Raises:
             ValueError: If submission_batch_size is not a positive integer.
         """
-        async with contextlib.aclosing(
-            self.iter_results(tasks_data, submission_batch_size=submission_batch_size)
+        async with self.iter_results(
+            tasks_data, submission_batch_size=submission_batch_size
         ) as results:
             result = [task async for task in results]
         return sorted(result, key=lambda task: int(task.task_id))
@@ -632,10 +649,13 @@ class Aqute(Generic[TData, TResult]):
     def apply_to_each(
         self, tasks_data: Iterable[TData] | AsyncIterable[TData]
     ) -> AsyncGenerator[AquteTask[TData, TResult]]:
-        """Deprecated; use iter_results(). Return its generator so aclose propagates."""
+        """Deprecated generator API; close partial iteration with aclose/aclosing.
+
+        Prefer ``async with engine.iter_results(items) as results`` in new code.
+        """
         warnings.warn(
             "apply_to_each() is deprecated; use iter_results()",
             DeprecationWarning,
             stacklevel=2,
         )
-        return self.iter_results(tasks_data)
+        return self._iter_results(tasks_data)

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,10 +23,12 @@ ordered list of doubled values and propagates handler errors.
 
 From a development checkout, run `uv run --locked python -m examples.quickstart`.
 
-`process_all(items)` returns a list in input order. `iter_results(items)` yields
-terminal results in completion order. Both accept `Iterable` and `AsyncIterable`
-inputs. Each `AquteTask` exposes `data`, `task_id`, `result`, `error`, and `success`.
-Inspect `error` or `success`: `None` can be a valid handler result.
+`await engine.process_all(items)` returns a list in input order. For
+completion-order streaming, use `async with engine.iter_results(items) as results`
+and iterate `results` inside the context. Both helpers accept `Iterable` and
+`AsyncIterable` inputs. Each terminal `AquteTask` exposes `data`, `task_id`, `result`,
+`error`, and `success`. Inspect `error` or `success`: `None` can be a valid handler
+result.
 
 See [usage](usage.md) for buffering, cleanup, retry, timeout, and compatibility
 contracts. The executable examples cover [streaming](streaming.md), a shared
@@ -45,7 +47,7 @@ decide which operations are safe to repeat. For remote inference, Aqute schedule
 handler attempts; model execution and provider-specific policy remain outside it.
 
 Configure both input and result queue limits to bound buffering; their defaults
-are unlimited. `process_all()` retains the complete result list. If streaming can
-stop early, close `iter_results()` with `contextlib.aclosing`. See
-[buffering and iterator cleanup](usage.md#buffering-and-iterator-cleanup) for the
-current lifecycle contract.
+are unlimited. `process_all()` retains the complete result list. The
+`iter_results()` context awaits producer and worker cleanup, including after early
+exit. See [streaming and cleanup](usage.md#streaming-and-cleanup) for the lifecycle
+contract.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,6 +1,38 @@
 # Usage
 
-## Buffering and iterator cleanup
+## Streaming and cleanup
+
+Use an async context to own streaming work:
+
+```python
+async with engine.iter_results(items) as results:
+    async for task in results:
+        consume(task)
+```
+
+Each call returns a context for one lazy, single-use iterator. The first iteration
+starts processing. Entering and leaving the context without iteration does not
+consume input or acquire ownership of its source. Results arrive in completion
+order as terminal `AquteTask` objects. `await engine.process_all(items)` owns the
+same context internally and returns a list in input order.
+
+Context exit waits for the producer and workers to stop after full consumption,
+an early `break`, a consumer exception, a source exception, or cancellation.
+Source and consumer errors propagate; handler errors remain task error values.
+Caller cancellation, including a deadline during cleanup, propagates through the
+existing cooperative cleanup path. Cleanup requires sources, handlers, and rate
+limiters to cooperate with cancellation; it cannot forcibly terminate them.
+Aqute closes started generator sources. Callers own other source resources,
+including custom iterators with `close()` or `aclose()` methods.
+
+Use each context and iterator once, and consume results inside the context.
+Use the engine sequentially. Before reusing it with a helper after partial
+consumption, call `drain_results()` to remove retained results. Otherwise, a helper
+can consume results from the previous run. Use a fresh engine when those results
+must remain in their original queue. Helpers own the run; use the manual API for
+externally managed producers and consumers.
+
+## Buffering
 
 Set both `input_task_queue_size=I` and `result_queue=asyncio.Queue(R)` to positive
 values to bound buffering. With `W` workers and one producer, Aqute retains at most
@@ -12,17 +44,6 @@ This is an item-count bound, not a byte limit. It excludes items retained by the
 source or caller and the growing list returned by `process_all()`. A queue size of
 zero is unlimited. Multiple independent producer calls can each hold an item
 while waiting for admission; the formula above assumes one producer.
-
-Use `async with contextlib.aclosing(engine.iter_results(items)) as results` when
-iteration can stop early. `async for` does not close an async generator after
-`break`. Closing or cancelling the iterator waits for its producer and workers.
-Aqute closes generator sources; callers own other source resources. Cleanup
-requires handlers and rate limiters to cooperate with cancellation.
-
-Before reusing an engine with a helper, call `drain_results()` to remove retained
-results. Otherwise, a helper can consume results from the previous run. Use a
-fresh engine when those results must remain in their original queue. Helpers own
-the run; use the manual API for externally managed producers and consumers.
 
 ## Concurrency, rate, and priority
 
@@ -163,9 +184,50 @@ breaking release; no removal version is currently scheduled.
 | `get_task_result()` | `await get_result()` |
 | `extract_all_results()` | `drain_results()` |
 | `apply_to_all(items)` | `await process_all(items)` |
-| `apply_to_each(items)` | `iter_results(items)` |
+| `apply_to_each(items)` | `async with iter_results(items) as results` |
 
 `start()`, `stop()`, and `add_task()` keep their names. Generic handler input and
 result types are preserved through both interfaces and the async context manager.
 For example, a handler accepting `int` makes `add_task("text")` a type error;
 this is an intentionally invalid call, not a runnable usage example.
+
+### Managed streaming migration
+
+This is a pre-1.0 signature and typing break for `iter_results()`. It is now a
+regular method returning
+`AbstractAsyncContextManager[AsyncIterator[AquteTask[TData, TResult]]]`, rather
+than an async generator returning `AsyncGenerator[AquteTask[TData, TResult]]`.
+The input remains `Iterable[TData] | AsyncIterable[TData]`; the keyword-only
+`submission_batch_size: int = 1` is unchanged. Validation still occurs on first
+iteration, before input consumption. No extra import or exported type is needed
+for normal use.
+
+Before:
+
+```python
+from contextlib import aclosing
+
+async with aclosing(engine.iter_results(items)) as results:
+    async for task in results:
+        consume(task)
+```
+
+After:
+
+```python
+async with engine.iter_results(items) as results:
+    async for task in results:
+        consume(task)
+```
+
+Also replace bare `async for task in engine.iter_results(items)` with the new
+context form. Call `anext(results)` on the iterator yielded by the context.
+Do not call `aclose()` on the context returned by `iter_results()`.
+
+Deprecated `apply_to_each(items)` retains its `AsyncGenerator` return type and
+warning. Existing `async for` callers still work. Use
+`async with contextlib.aclosing(engine.apply_to_each(items)) as results` or
+explicitly await that generator's `aclose()` when stopping early. Its compatibility
+wrapper shares the same processing and cleanup path; migrate new code to the
+managed `iter_results()` form. `process_all()` keeps its coroutine signature and
+ordered list return type.

--- a/examples/http_client.py
+++ b/examples/http_client.py
@@ -3,7 +3,6 @@
 import asyncio
 import logging
 from collections.abc import AsyncIterable, Iterable
-from contextlib import aclosing
 
 import httpx
 
@@ -33,7 +32,7 @@ async def fetch_pages(
             specific_errors_to_retry=httpx.TransportError,
         )
         pages = []
-        async with aclosing(engine.iter_results(urls)) as results:
+        async with engine.iter_results(urls) as results:
             async for task in results:
                 if task.error is not None:
                     raise task.error

--- a/examples/streaming.py
+++ b/examples/streaming.py
@@ -3,7 +3,6 @@
 import asyncio
 import logging
 from collections import Counter
-from contextlib import aclosing
 from random import uniform
 
 from aqute import Aqute
@@ -40,7 +39,7 @@ async def main() -> list[int]:
         specific_errors_to_retry=ValueError,
     )
     values = []
-    async with aclosing(engine.iter_results(source())) as results:
+    async with engine.iter_results(source()) as results:
         async for task in results:
             if task.error is not None:
                 raise task.error

--- a/scripts/benchmark.py
+++ b/scripts/benchmark.py
@@ -12,7 +12,6 @@ import json
 import platform
 import sys
 import time
-from contextlib import aclosing
 
 import aqute
 from aqute import Aqute
@@ -69,9 +68,7 @@ class Work:
             options = (
                 {} if batch_size is None else {"submission_batch_size": batch_size}
             )
-            async with aclosing(
-                engine.iter_results(self.source(), **options)
-            ) as results:
+            async with engine.iter_results(self.source(), **options) as results:
                 async for task in results:
                     self.consume(task)
         else:

--- a/tests/aqute/test_api_names.py
+++ b/tests/aqute/test_api_names.py
@@ -1,7 +1,8 @@
 import asyncio
 import contextlib
 import warnings
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, AsyncIterator
+from contextlib import AbstractAsyncContextManager
 from pathlib import Path
 from typing import assert_type
 
@@ -39,9 +40,13 @@ async def test_canonical_methods_preserve_types_without_deprecation_warnings():
         results = await engine.process_all([4, 5])
         assert_type(results, list[AquteTask[int, str]])
         assert [item.result for item in results] == ["4", "5"]
-        stream = engine.iter_results([6])
-        assert_type(stream, AsyncGenerator[AquteTask[int, str]])
-        assert [item.result async for item in stream] == ["6"]
+        context = engine.iter_results([6])
+        assert_type(
+            context, AbstractAsyncContextManager[AsyncIterator[AquteTask[int, str]]]
+        )
+        async with context as stream:
+            assert_type(stream, AsyncIterator[AquteTask[int, str]])
+            assert [item.result async for item in stream] == ["6"]
 
 
 @pytest.mark.asyncio
@@ -112,14 +117,15 @@ async def test_iterator_names_close_the_owned_work(legacy):
     engine = Aqute(stringify, 1)
     if legacy:
         with pytest.warns(DeprecationWarning, match="use iter_results") as caught:
-            stream = engine.apply_to_each(source())
+            legacy_stream = engine.apply_to_each(source())
         assert len(caught) == 1
         assert Path(caught[0].filename) == Path(__file__)
-        assert_type(stream, AsyncGenerator[AquteTask[int, str]])
+        assert_type(legacy_stream, AsyncGenerator[AquteTask[int, str]])
+        context = contextlib.aclosing(legacy_stream)
     else:
-        stream = engine.iter_results(source())
+        context = engine.iter_results(source())
     async with asyncio.timeout(1):
-        async with contextlib.aclosing(stream):
+        async with context as stream:
             assert (await anext(stream)).result == "1"
             await waiting.wait()
     assert cleaned.is_set()

--- a/tests/aqute/test_backoff.py
+++ b/tests/aqute/test_backoff.py
@@ -98,7 +98,8 @@ async def test_backoff_does_not_block_other_available_worker():
         return 0.05
 
     engine = Aqute(handler, 2, retry_count=1, retry_delay=delay)
-    results = [result async for result in engine.iter_results([1, 2])]
+    async with engine.iter_results([1, 2]) as stream:
+        results = [result async for result in stream]
     assert [result.result for result in results] == [2, 1]
     assert attempts == {1: 2, 2: 1}
 
@@ -156,9 +157,10 @@ async def test_delayed_retries_obey_rate_limit_and_bounded_streaming():
     )
     async with asyncio.timeout(2):
         results = []
-        async for result in engine.iter_results(range(4)):
-            results.append(result)
-            await asyncio.sleep(0.025)
+        async with engine.iter_results(range(4)) as stream:
+            async for result in stream:
+                results.append(result)
+                await asyncio.sleep(0.025)
     assert all(result.success for result in results)
     assert {result.result for result in results} == set(range(4))
     assert attempts == Counter({value: 2 for value in range(4)})

--- a/tests/aqute/test_errors.py
+++ b/tests/aqute/test_errors.py
@@ -96,10 +96,11 @@ async def test_too_many_failed_tasks_error_with_helper_each(
 
     async with asyncio.timeout(1):
         with pytest.raises(AquteTooManyTasksFailedError) as exc:
-            async for _ in aqute.iter_results(
+            async with aqute.iter_results(
                 range(1, 6), submission_batch_size=batch_size
-            ):
-                pass
+            ) as results:
+                async for _ in results:
+                    pass
     assert "limit reached: 1" in str(exc.value)
 
 

--- a/tests/aqute/test_helper_flows.py
+++ b/tests/aqute/test_helper_flows.py
@@ -46,8 +46,9 @@ async def test_iter_results():
     )
     results = []
 
-    async for r in aqute.iter_results(range(10)):
-        results.append(r)
+    async with aqute.iter_results(range(10)) as stream:
+        async for r in stream:
+            results.append(r)
 
     successes = [t for t in results if t.success]
     assert len(successes) == 9

--- a/tests/aqute/test_stop_cancellation.py
+++ b/tests/aqute/test_stop_cancellation.py
@@ -55,8 +55,8 @@ async def test_stop_preserves_the_callers_deadline(kind):
 
 
 @pytest.mark.asyncio
-async def test_iterator_close_preserves_the_callers_deadline():
-    """A deadline during source cleanup must propagate from the public iterator."""
+async def test_stream_context_exit_preserves_the_callers_deadline():
+    """A deadline during source cleanup must propagate from context exit."""
     release = asyncio.Event()
     cleaning = asyncio.Event()
     closed = asyncio.Event()
@@ -76,12 +76,12 @@ async def test_iterator_close_preserves_the_callers_deadline():
         return value
 
     engine = Aqute(handle, 1)
-    stream = engine.iter_results(source())
-    assert (await anext(stream)).result == 1
 
     async def close_with_deadline():
-        async with asyncio.timeout(0.02):
-            await stream.aclose()
+        deadline = asyncio.timeout(None)
+        async with deadline, engine.iter_results(source()) as stream:
+            assert (await anext(stream)).result == 1
+            deadline.reschedule(asyncio.get_running_loop().time() + 0.02)
 
     closing = asyncio.create_task(close_with_deadline())
     try:
@@ -98,5 +98,4 @@ async def test_iterator_close_preserves_the_callers_deadline():
         closing.cancel()
         with contextlib.suppress(asyncio.CancelledError, TimeoutError):
             await closing
-        await stream.aclose()
         await engine.stop()

--- a/tests/aqute/test_streaming.py
+++ b/tests/aqute/test_streaming.py
@@ -1,6 +1,7 @@
 import asyncio
 import contextlib
 from collections import Counter
+from io import StringIO
 
 import pytest
 
@@ -27,8 +28,8 @@ async def test_invalid_submission_batch_does_not_consume_input(collect, batch_si
         if collect:
             await engine.process_all(source(), submission_batch_size=batch_size)
         else:
-            async with contextlib.aclosing(
-                engine.iter_results(source(), submission_batch_size=batch_size)
+            async with engine.iter_results(
+                source(), submission_batch_size=batch_size
             ) as results:
                 await anext(results)
     assert consumed == []
@@ -68,7 +69,8 @@ async def test_submission_batch_gives_ready_coroutines_a_turn(
         if collect:
             results = await engine.process_all(items, **options)
         else:
-            results = [result async for result in engine.iter_results(items, **options)]
+            async with engine.iter_results(items, **options) as stream:
+                results = [result async for result in stream]
         assert observer is not None
         assert await observer == (1 if batch_size is None else batch_size)
     assert [
@@ -84,11 +86,24 @@ async def test_submission_batch_gives_ready_coroutines_a_turn(
 async def test_helpers_complete_with_bounded_queues(
     collect, asynchronous, values, batch_size
 ):
-    async def source():
-        for value in values:
-            yield value
+    """Full consumption returns each result and finishes generator source cleanup."""
+    closed = []
 
-    items = source() if asynchronous else iter(values)
+    def source():
+        try:
+            yield from values
+        finally:
+            closed.append(True)
+
+    async def async_source():
+        try:
+            for value in values:
+                yield value
+        finally:
+            await asyncio.sleep(0)
+            closed.append(True)
+
+    items = async_source() if asynchronous else source()
     engine = Aqute(
         echo,
         1,
@@ -100,14 +115,13 @@ async def test_helpers_complete_with_bounded_queues(
         if collect:
             results = await engine.process_all(items, submission_batch_size=batch_size)
         else:
-            results = [
-                result
-                async for result in engine.iter_results(
-                    items, submission_batch_size=batch_size
-                )
-            ]
+            async with engine.iter_results(
+                items, submission_batch_size=batch_size
+            ) as stream:
+                results = [result async for result in stream]
     assert [result.result for result in results] == values
     assert all(result.success for result in results)
+    assert closed == [True]
 
 
 @pytest.mark.asyncio
@@ -121,8 +135,8 @@ async def test_first_result_precedes_async_source_exhaustion(batch_size):
         yield 2
 
     engine = Aqute(echo, 1)
-    async with contextlib.aclosing(
-        engine.iter_results(source(), submission_batch_size=batch_size)
+    async with engine.iter_results(
+        source(), submission_batch_size=batch_size
     ) as results:
         async with asyncio.timeout(1):
             assert (await anext(results)).result == 1
@@ -143,9 +157,7 @@ async def test_iterator_yields_in_completion_order(batch_size):
         return value
 
     engine = Aqute(handler, 2, input_task_queue_size=1)
-    async with contextlib.aclosing(
-        engine.iter_results([1, 2], submission_batch_size=batch_size)
-    ) as results:
+    async with engine.iter_results([1, 2], submission_batch_size=batch_size) as results:
         async with asyncio.timeout(1):
             assert (await anext(results)).result == 2
             release.set()
@@ -205,8 +217,8 @@ async def test_slow_consumption_bounds_production_and_handlers(manual, batch_siz
                     with contextlib.suppress(asyncio.CancelledError):
                         await producer
         else:
-            async with contextlib.aclosing(
-                engine.iter_results(source(), submission_batch_size=batch_size)
+            async with engine.iter_results(
+                source(), submission_batch_size=batch_size
             ) as stream:
                 first = await anext(stream)
                 with pytest.raises(TimeoutError):
@@ -245,11 +257,12 @@ async def test_retries_complete_with_slow_consumption_and_bounded_queues(
     )
     async with asyncio.timeout(2):
         results = []
-        async for result in engine.iter_results(
+        async with engine.iter_results(
             range(20), submission_batch_size=batch_size
-        ):
-            results.append(result)
-            await asyncio.sleep(0.001)
+        ) as stream:
+            async for result in stream:
+                results.append(result)
+                await asyncio.sleep(0.001)
     assert all(result.success for result in results)
     assert [
         result.result for result in sorted(results, key=lambda task: task.data)
@@ -259,7 +272,9 @@ async def test_retries_complete_with_slow_consumption_and_bounded_queues(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("batch_size", [1, 32])
-async def test_source_failure_cancels_active_handler(batch_size):
+@pytest.mark.parametrize("collect", [False, True])
+async def test_source_failure_cancels_active_handler(batch_size, collect):
+    """A source error reaches the caller after active handler cleanup completes."""
     started = asyncio.Event()
     cleaned = asyncio.Event()
 
@@ -269,6 +284,7 @@ async def test_source_failure_cancels_active_handler(batch_size):
             await asyncio.Event().wait()
             return value
         finally:
+            await asyncio.sleep(0)
             cleaned.set()
 
     async def source():
@@ -279,14 +295,24 @@ async def test_source_failure_cancels_active_handler(batch_size):
     engine = Aqute(handler, 1, input_task_queue_size=1)
     async with asyncio.timeout(1):
         with pytest.raises(ValueError, match="source failed"):
-            await engine.process_all(source(), submission_batch_size=batch_size)
+            if collect:
+                await engine.process_all(source(), submission_batch_size=batch_size)
+            else:
+                async with engine.iter_results(
+                    source(), submission_batch_size=batch_size
+                ) as results:
+                    await anext(results)
     assert cleaned.is_set()
 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("asynchronous", [False, True])
 @pytest.mark.parametrize("batch_size", [1, 32])
-async def test_iterator_close_cleans_source_and_handler(asynchronous, batch_size):
+@pytest.mark.parametrize("consumer_error", [False, True])
+async def test_context_exit_cleans_source_and_handler(
+    asynchronous, batch_size, consumer_error
+):
+    """Break or consumer failure must await cleanup and allow engine reuse."""
     started = asyncio.Event()
     cleaned = asyncio.Event()
     source_closed = asyncio.Event()
@@ -297,6 +323,7 @@ async def test_iterator_close_cleans_source_and_handler(asynchronous, batch_size
             try:
                 await asyncio.Event().wait()
             finally:
+                await asyncio.sleep(0)
                 cleaned.set()
         return value
 
@@ -311,43 +338,95 @@ async def test_iterator_close_cleans_source_and_handler(asynchronous, batch_size
             for value in range(100):
                 yield value
         finally:
+            await asyncio.sleep(0)
             source_closed.set()
 
     engine = Aqute(handler, 1, input_task_queue_size=1, result_queue=asyncio.Queue(1))
     items = async_source() if asynchronous else source()
-    async with asyncio.timeout(1):
-        async with contextlib.aclosing(
-            engine.iter_results(items, submission_batch_size=batch_size)
+
+    async def consume():
+        async with engine.iter_results(
+            items, submission_batch_size=batch_size
         ) as results:
-            assert (await anext(results)).result == 0
-            await started.wait()
+            async for result in results:
+                assert result.result == 0
+                await started.wait()
+                if consumer_error:
+                    raise ValueError("consumer failed")
+                break
+
+    async with asyncio.timeout(1):
+        operation = asyncio.create_task(consume())
+        error_context = (
+            pytest.raises(ValueError, match="consumer failed")
+            if consumer_error
+            else contextlib.nullcontext()
+        )
+        with error_context:
+            await operation
     assert cleaned.is_set()
     assert source_closed.is_set()
     assert (await engine.process_all([0]))[0].result == 0
 
 
 @pytest.mark.asyncio
-async def test_cancelling_collection_cleans_waiting_source():
+@pytest.mark.parametrize(
+    ("collect", "consume_result"), [(True, False), (False, False), (False, True)]
+)
+async def test_cancelling_helper_cleans_waiting_source(collect, consume_result):
+    """Cancellation during iteration or consumption awaits source/handler cleanup."""
     started = asyncio.Event()
     cleaned = asyncio.Event()
+    handled = asyncio.Event()
+    handler_cleaned = asyncio.Event()
+    consuming = asyncio.Event()
+
+    async def handler(value: int) -> int:
+        if value:
+            handled.set()
+            try:
+                await asyncio.Event().wait()
+            finally:
+                await asyncio.sleep(0)
+                handler_cleaned.set()
+        return value
 
     async def source():
         try:
+            yield 0
+            yield 1
             started.set()
             await asyncio.Event().wait()
-            yield 1
         finally:
+            await asyncio.sleep(0)
             cleaned.set()
 
-    engine = Aqute(echo, 1)
-    operation = asyncio.create_task(engine.process_all(source()))
+    engine = Aqute(handler, 1)
+
+    async def consume():
+        if collect:
+            await engine.process_all(source())
+        else:
+            async with engine.iter_results(source()) as results:
+                assert (await anext(results)).result == 0
+                consuming.set()
+                if consume_result:
+                    await asyncio.Event().wait()
+                else:
+                    await anext(results)
+
+    operation = asyncio.create_task(consume())
     async with asyncio.timeout(1):
         await started.wait()
+        await handled.wait()
+        if not collect:
+            await consuming.wait()
         operation.cancel()
         with pytest.raises(asyncio.CancelledError):
             await operation
     assert cleaned.is_set()
-    assert (await engine.process_all([1]))[0].success
+    assert handler_cleaned.is_set()
+    assert (await engine.process_all([0]))[0].success
 
 
 @pytest.mark.asyncio
@@ -364,8 +443,8 @@ async def test_drain_retained_results_before_reusing_helper(batch_size):
 
     engine = Aqute(handler, 2)
     async with asyncio.timeout(1):
-        async with contextlib.aclosing(
-            engine.iter_results([1, 2, 3], submission_batch_size=batch_size)
+        async with engine.iter_results(
+            [1, 2, 3], submission_batch_size=batch_size
         ) as results:
             first = await anext(results)
             await completed.wait()
@@ -375,3 +454,58 @@ async def test_drain_retained_results_before_reusing_helper(batch_size):
         assert sorted([first.data, *[result.data for result in retained]]) == [1, 2, 3]
         fresh = await engine.process_all([4])
     assert [result.result for result in fresh] == [4]
+
+
+@pytest.mark.asyncio
+async def test_context_without_iteration_does_not_acquire_input():
+    """An unused context leaves input untouched and its closed iterator cannot start."""
+    acquired = []
+
+    class Source:
+        def __iter__(self):
+            acquired.append(True)
+            return iter([1])
+
+    engine = Aqute(echo, 1)
+    source = Source()
+    async with engine.iter_results(source) as results:
+        assert acquired == []
+    with pytest.raises(StopAsyncIteration):
+        await anext(results)
+    assert acquired == []
+    assert (await engine.process_all(source))[0].result == 1
+    assert acquired == [True]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("asynchronous", [False, True])
+async def test_context_leaves_custom_source_resource_open(asynchronous):
+    """Closing a partial stream must leave non-generator source resources usable."""
+    resource = StringIO("1\n" * 100)
+
+    class AsyncLines:
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            line = resource.readline()
+            if not line:
+                raise StopAsyncIteration
+            return line
+
+        async def aclose(self):
+            resource.close()
+
+    async def parse(line: str) -> int:
+        return int(line)
+
+    engine = Aqute(parse, 1, input_task_queue_size=1, result_queue=asyncio.Queue(1))
+    try:
+        source = AsyncLines() if asynchronous else resource
+        async with engine.iter_results(source) as results:
+            assert (await anext(results)).result == 1
+        assert not resource.closed
+        resource.seek(0)
+        assert resource.readline() == "1\n"
+    finally:
+        resource.close()


### PR DESCRIPTION
`iter_results()` now owns streaming cleanup through `async with engine.iter_results(items) as results`. Exiting after completion, early break, error, or cancellation awaits the existing producer/worker cleanup path. `process_all()` owns the context internally; deprecated `apply_to_each()` keeps its generator compatibility. Usage documentation explains the pre-1.0 signature change and migration.

Validation: final `make check build` passed (260 tests), Python 3.11 wheel smoke and rendered link/source checks passed. Full tests and wheels passed on Python 3.11–3.14 for the byte-identical implementation. Initial and final cold Claude reviews and the documentation audit completed with no upheld findings.

Performance qualification compared working baseline `de9135a` with implementation `282083f` using identical W32/queue32 buffering, warmup and five interleaved repetitions. Longer Python 3.14 confirmation measured immediate tasks at 90,236 → 87,960/s (−2.5%, CV 3.4%/3.6%) and local TCP at 30,429 → 31,712/s (+4.2%, CV 5.8%). Ranges overlap; the initial noisy TCP slowdown did not reproduce. These shared-host measurements do not establish zero overhead or a speedup. All 100 samples passed correctness and buffering checks.

Zhournal: `task:aqute-managed-streaming-v1` (revision 1); final candidate `4224aa5a68e2aea81f387a02e2ddde520ee4ae2e`.
