### PR TITLE
feat: add typed terminal task unwrap

### DIFF
--- a/aqute/task.py
+++ b/aqute/task.py
@@ -1,6 +1,8 @@
 import asyncio
 from dataclasses import dataclass
-from typing import Generic, NamedTuple, TypeVar
+from typing import Generic, NamedTuple, TypeVar, cast
+
+from aqute.errors import AquteError
 
 END_MARKER = object()
 
@@ -30,6 +32,19 @@ class AquteTask(Generic[TData, TResult]):
 
     _remaining_tries: int = 0
     _priority: int = 1_000_000
+
+    def unwrap(self) -> TResult:
+        """Return a successful terminal result, including None, or raise its error.
+
+        Call this after receiving a completed task. A pending task raises AquteError.
+        Calling unwrap after process_all does not make processing fail fast:
+        the batch has already completed.
+        """
+        if self.error is not None:
+            raise self.error
+        if not self.success:
+            raise AquteError(f"Task {self.task_id} is not complete")
+        return cast(TResult, self.result)
 
     def __lt__(self, other: "AquteTask") -> bool:
         """Used for priority queue sorting"""

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,5 +1,19 @@
 # Usage
 
+## Task results
+
+Call `AquteTask.unwrap()` after receiving a terminal task. It returns `TResult`
+on success, including `None` when that is a valid handler result. On failure, it
+raises the stored exception. A pending task raises `AquteError`.
+
+`unwrap()` does not change the task's outcome fields. Keep inspecting `data`,
+`result`, `error`, and `success` when collecting partial failures.
+
+The [runnable quickstart](index.md#quickstart) collects values with
+`values = [task.unwrap() for task in tasks]` after `process_all()` returns.
+The batch has already finished when `unwrap()` runs, so this does not make
+processing fail fast.
+
 ## Streaming and cleanup
 
 Use an async context to own streaming work:

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -2,9 +2,10 @@
 
 ## Task results
 
-Call `AquteTask.unwrap()` after receiving a terminal task. It returns `TResult`
-on success, including `None` when that is a valid handler result. On failure, it
-raises the stored exception. A pending task raises `AquteError`.
+Call `AquteTask.unwrap()` on terminal results obtained from `Aqute` through
+`process_all()`, `iter_results()`, `get_result()`, or `drain_results()`. It returns
+`TResult` on success, including `None` when that is a valid handler result.
+On failure, it raises the stored exception. A pending task raises `AquteError`.
 
 `unwrap()` does not change the task's outcome fields. Keep inspecting `data`,
 `result`, `error`, and `success` when collecting partial failures.
@@ -162,6 +163,10 @@ retained results before using a helper again. For lower-level worker queues,
 `aqute.worker.Foreman` exposes `start()`, `add_task(AquteTask(...))`,
 `get_handled_task()`, `finalize()`, and `stop()`. Consume finite result queues while
 waiting for `finalize()`.
+
+Inspect `error` and `result` on tasks returned directly by `Foreman`. It does not
+set `success`; `unwrap()` requires the engine's terminal success flag to return
+a value.
 
 ## Progress counters
 

--- a/examples/quickstart.py
+++ b/examples/quickstart.py
@@ -12,12 +12,7 @@ async def handle(value: int) -> int:
 
 async def main() -> list[int]:
     tasks = await Aqute(handle, workers_count=4).process_all(range(10))
-    values = []
-    for task in tasks:
-        if task.error is not None:
-            raise task.error
-        assert task.result is not None
-        values.append(task.result)
+    values = [task.unwrap() for task in tasks]
     assert values == [value * 2 for value in range(10)]
     return values
 

--- a/tests/aqute/test_task_unwrap.py
+++ b/tests/aqute/test_task_unwrap.py
@@ -1,0 +1,72 @@
+from typing import assert_type
+
+import pytest
+
+from aqute import Aqute, AquteError, AquteTask
+
+
+@pytest.mark.asyncio
+async def test_unwrap_returns_typed_successful_value():
+    """A completed result must retain the handler's int type and public outcome."""
+
+    async def handle(value: int) -> int:
+        return value * 2
+
+    (task,) = await Aqute(handle, workers_count=1).process_all([21])
+
+    assert assert_type(task.unwrap(), int) == 42
+    assert task.data == 21
+    assert task.result == 42
+    assert task.error is None
+    assert task.success
+
+
+@pytest.mark.asyncio
+async def test_unwrap_distinguishes_successful_none_from_pending():
+    """Unwrap must distinguish successful None from an unchanged pending outcome."""
+    pending = AquteTask[int, None](data=1, task_id="pending")
+
+    with pytest.raises(AquteError, match="Task pending is not complete"):
+        pending.unwrap()
+
+    assert pending.data == 1
+    assert pending.task_id == "pending"
+    assert pending.result is None
+    assert pending.error is None
+    assert not pending.success
+
+    async def handle(_value: int) -> None:
+        return None
+
+    (task,) = await Aqute(handle, workers_count=1).process_all([1])
+
+    assert assert_type(task.unwrap(), None) is None
+    assert task.data == 1
+    assert task.result is None
+    assert task.error is None
+    assert task.success
+
+
+@pytest.mark.asyncio
+async def test_unwrap_raises_stored_error_after_batch_completion():
+    """Unwrap must raise the stored error after the full batch has completed."""
+    handled = []
+    error = ValueError("handler failed")
+
+    async def handle(value: int) -> int:
+        handled.append(value)
+        if value == 1:
+            raise error
+        return value * 2
+
+    tasks = await Aqute(handle, workers_count=1).process_all([1, 2])
+
+    assert handled == [1, 2]
+    assert [task.data for task in tasks] == [1, 2]
+    with pytest.raises(ValueError, match="handler failed") as caught:
+        tasks[0].unwrap()
+    assert caught.value is error
+    assert tasks[0].error is error
+    assert tasks[0].result is None
+    assert not tasks[0].success
+    assert tasks[1].unwrap() == 4


### PR DESCRIPTION
`AquteTask.unwrap()` returns a successful terminal value, including `None`, and raises the stored handler exception. Pending tasks raise `AquteError`. The method preserves the existing result fields and error-as-value behavior; calling it after `process_all()` does not make the batch fail fast.

The quickstart now collects typed values with `unwrap()`. Usage guidance covers engine terminal results, partial failures, and the lower-level `Foreman` boundary.

Validation: `make check` passed 263 tests, lint, typing, coverage and strict documentation checks. `make build`, the executable quickstart, and the Python 3.11 installed-wheel smoke check passed. Focused typing checks preserve `int` and valid `None`. Cold Claude implementation and documentation reviews are recorded in Zhournal; the verified documentation minor was corrected and reviewed separately.
