### PR TITLE
feat: bound helper queues by default

### DIFF
--- a/aqute/engine.py
+++ b/aqute/engine.py
@@ -373,7 +373,8 @@ class Aqute(Generic[TData, TResult]):
     def _helper_queues(self) -> Generator[None]:
         if self.aiotask_of_run_load is not None or self._added_tasks_count:
             raise AquteError(
-                "Helper runs require no active run or pending manual tasks"
+                "Use a fresh engine, or complete and stop the existing run "
+                "before starting a helper"
             )
         original_result_queue = self.result_queue
         if self._owns_result_queue:

--- a/aqute/engine.py
+++ b/aqute/engine.py
@@ -43,7 +43,7 @@ class Aqute(Generic[TData, TResult]):
         | type[Exception]
         | None = None,
         start_timeout_seconds: int | float | None = None,
-        input_task_queue_size: int = 0,
+        input_task_queue_size: int | None = None,
         use_priority_queue: bool = False,
         task_timeout_seconds: int | float | None = None,
         total_failed_tasks_limit: int | None = None,
@@ -57,8 +57,10 @@ class Aqute(Generic[TData, TResult]):
             workers_count: Number of workers for processing.
             rate_limiter (optional): Limiter for processing rate.
                 Defaults to None.
-            result_queue (optional): Queue for task results. Defaults
-                to None.
+            result_queue (optional): Caller-owned queue for task results. Its
+                capacity also limits the internal result relay; 0 is unlimited.
+                If omitted, helpers use workers_count items per result queue;
+                manual runs use an unlimited queue.
             retry_count (optional): Number of task retry attempts upon
                 failure. Defaults to 0.
             retry_delay (optional): Map the 1-based failed-attempt number and
@@ -71,8 +73,10 @@ class Aqute(Generic[TData, TResult]):
                 Defaults to None.
             start_timeout_seconds (optional): Wait time before failing after start
                 if no tasks were added. Defaults to None.
-            input_task_queue_size (optional): Max size of the input task
-                queue. 0 indicates unlimited. Defaults to 0.
+            input_task_queue_size (optional): Maximum pending input items.
+                None (the default) uses workers_count for helper runs and no
+                limit for manual runs. Positive values set an explicit capacity;
+                0 is unlimited for both APIs.
             use_priority_queue (optional): Use priority queue for tasks.
                 Defaults to False.
             task_timeout_seconds (optional): Timeout for task handler coroutine wait.
@@ -82,12 +86,13 @@ class Aqute(Generic[TData, TResult]):
             total_failed_tasks_limit (optional): Maximum failed tasks count before
                 stopping processing. Defaults to None.
         """
+        self._owns_result_queue = result_queue is None
         self.result_queue: AquteTaskQueueType[TData, TResult] = (
-            result_queue or asyncio.Queue()
+            asyncio.Queue() if result_queue is None else result_queue
         )
 
         self._task_tries_count = max(retry_count, 0) + 1
-        self._input_task_queue_size = max(input_task_queue_size, 0)
+        self._input_task_queue_size = input_task_queue_size
 
         self._rate_limiter = rate_limiter
 
@@ -103,7 +108,7 @@ class Aqute(Generic[TData, TResult]):
             handle_coro=self._handle_coro,
             workers_count=self._workers_count,
             rate_limiter=self._rate_limiter,
-            input_task_queue_size=self._input_task_queue_size,
+            input_task_queue_size=max(self._input_task_queue_size or 0, 0),
             use_priority_queue=self._use_priority_queue,
             task_timeout_seconds=self._task_timeout_seconds,
             output_task_queue_size=self.result_queue.maxsize,
@@ -289,6 +294,15 @@ class Aqute(Generic[TData, TResult]):
         and handlers. Drain retained results before reusing the engine.
         Source exceptions propagate after cancelling owned processing.
 
+        Omitted queue limits use workers_count items for pending input, results,
+        and the internal result relay. With finite input capacity I, result
+        capacity R, and W workers, at most I + 2R + W + 3 generated items can be
+        outstanding, including the currently yielded item. Defaults give 4W + 3.
+        These are item bounds, not byte bounds; source and caller retention are
+        excluded. Explicit input_task_queue_size=0 or result_queue=Queue(0)
+        disables the corresponding limit. Supplied result queues retain their
+        identity and capacity. Manual runs keep their original queue limits.
+
         Args:
             tasks_data: Iterable containing data for each task.
             submission_batch_size: Positive number of inputs to admit between
@@ -304,6 +318,9 @@ class Aqute(Generic[TData, TResult]):
         Raises:
             ValueError: If submission_batch_size is not a positive integer.
                 Validation occurs when iteration starts, before consuming input.
+            AquteError: If a run is already started, manual tasks are pending,
+                or an automatically owned result queue has retained results.
+                Drain retained results before starting another helper run.
         """
         return contextlib.aclosing(
             self._iter_results(tasks_data, submission_batch_size=submission_batch_size)
@@ -317,39 +334,67 @@ class Aqute(Generic[TData, TResult]):
     ) -> AsyncGenerator[AquteTask[TData, TResult]]:
         if not isinstance(submission_batch_size, int) or submission_batch_size < 1:
             raise ValueError("submission_batch_size must be a positive integer")
-        async with self:
-            load = self.start()
-            producer = asyncio.create_task(
-                self._produce_tasks(tasks_data, submission_batch_size),
-                name="aqute-producer",
-            )
-            changed = self._results_changed
-            producer.add_done_callback(lambda _: changed.set())
-            exposed = 0
-            try:
-                while not producer.done() or exposed < self._added_tasks_count:
-                    if producer.done():
-                        await producer
-                    if not self.result_queue.empty():
-                        exposed += 1
-                        yield self.result_queue.get_nowait()
-                        continue
-                    if load.done():
-                        await load
-                    changed.clear()
-                    await changed.wait()
-                await producer
-                await load
-            finally:
-                producer.cancel()
-                caller = asyncio.current_task()
-                assert caller is not None
-                cancelling = caller.cancelling()
+        with self._helper_queues():
+            async with self:
+                load = self.start()
+                producer = asyncio.create_task(
+                    self._produce_tasks(tasks_data, submission_batch_size),
+                    name="aqute-producer",
+                )
+                changed = self._results_changed
+                producer.add_done_callback(lambda _: changed.set())
+                exposed = 0
                 try:
+                    while not producer.done() or exposed < self._added_tasks_count:
+                        if producer.done():
+                            await producer
+                        if not self.result_queue.empty():
+                            exposed += 1
+                            yield self.result_queue.get_nowait()
+                            continue
+                        if load.done():
+                            await load
+                        changed.clear()
+                        await changed.wait()
                     await producer
-                except asyncio.CancelledError:
-                    if caller.cancelling() > cancelling:
-                        raise
+                    await load
+                finally:
+                    producer.cancel()
+                    caller = asyncio.current_task()
+                    assert caller is not None
+                    cancelling = caller.cancelling()
+                    try:
+                        await producer
+                    except asyncio.CancelledError:
+                        if caller.cancelling() > cancelling:
+                            raise
+
+    @contextlib.contextmanager
+    def _helper_queues(self) -> Generator[None]:
+        if self.aiotask_of_run_load is not None or self._added_tasks_count:
+            raise AquteError(
+                "Helper runs require no active run or pending manual tasks"
+            )
+        original_result_queue = self.result_queue
+        if self._owns_result_queue:
+            if not original_result_queue.empty():
+                raise AquteError("Drain retained results before starting a helper run")
+            self.result_queue = asyncio.Queue(self._workers_count)
+        self._foreman.reset(
+            input_task_queue_size=(
+                self._workers_count
+                if self._input_task_queue_size is None
+                else max(self._input_task_queue_size, 0)
+            ),
+            output_task_queue_size=self.result_queue.maxsize,
+        )
+        try:
+            yield
+        finally:
+            if self._owns_result_queue:
+                while not self.result_queue.empty():
+                    original_result_queue.put_nowait(self.result_queue.get_nowait())
+                self.result_queue = original_result_queue
 
     async def _produce_tasks(
         self,
@@ -395,6 +440,8 @@ class Aqute(Generic[TData, TResult]):
         Each item in `tasks_data` is added as a task for processing. The method
         waits until all tasks are completed. Results are collected and returned
         in a list, maintaining the order of the input iterable.
+        Internal queues follow iter_results() limits. The returned list retains
+        all results, so total memory can still grow with input length.
 
         Args:
             tasks_data: Iterable containing data items for the tasks.

--- a/aqute/worker.py
+++ b/aqute/worker.py
@@ -282,17 +282,36 @@ class Foreman(Generic[TData, TResult]):
         finally:
             self.reset()
 
-    def reset(self) -> None:
+    def reset(
+        self,
+        *,
+        input_task_queue_size: int | None = None,
+        output_task_queue_size: int | None = None,
+    ) -> None:
         """
         Resets the Foreman state.
 
         Via re-initializing worker input and output queues,
         re-creating the worker instances, and clearing
         the worker supervisor. Call only after workers have stopped.
+        Capacity overrides apply to this reset only; later resets use the
+        constructor capacities.
         """
         logger.debug("Resetting workers")
-        self.in_queue = self._create_task_queue(size=self._input_task_queue_size)
-        self.out_queue = asyncio.Queue(maxsize=self._output_task_queue_size)
+        self.in_queue = self._create_task_queue(
+            size=(
+                self._input_task_queue_size
+                if input_task_queue_size is None
+                else input_task_queue_size
+            )
+        )
+        self.out_queue = asyncio.Queue(
+            maxsize=(
+                self._output_task_queue_size
+                if output_task_queue_size is None
+                else output_task_queue_size
+            )
+        )
         self._results_changed = asyncio.Event()
         self._workers = [
             Worker(

--- a/docs/index.md
+++ b/docs/index.md
@@ -46,8 +46,12 @@ For infrastructure changes, retries can repeat side effects; the application mus
 decide which operations are safe to repeat. For remote inference, Aqute schedules
 handler attempts; model execution and provider-specific policy remain outside it.
 
-Configure both input and result queue limits to bound buffering; their defaults
-are unlimited. `process_all()` retains the complete result list. The
-`iter_results()` context awaits producer and worker cleanup, including after early
-exit. See [streaming and cleanup](usage.md#streaming-and-cleanup) for the lifecycle
-contract.
+`process_all()` and `iter_results()` use finite input and result buffering by
+default, with each queue sized to `workers_count`. Manual processing keeps
+unlimited defaults. Queue limits bound items, not bytes; `process_all()` retains
+the complete result list. See [buffering](usage.md#buffering) for overrides, the
+item bound, and migration.
+
+The `iter_results()` context awaits producer and worker cleanup, including after
+early exit. See [streaming and cleanup](usage.md#streaming-and-cleanup) for the
+lifecycle contract.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -45,9 +45,9 @@ Use the engine sequentially. Before reusing it with a helper after partial
 consumption, call `drain_results()` to remove retained results. Helpers reject
 retained results in an automatically created result queue. Drain supplied queues
 too; helpers consume from them. Use a fresh engine when those results must remain
-in their original queue. Helpers require no active run or pending manual tasks;
-conflicting setup raises `AquteError` before consuming input. Use the manual API
-for externally managed producers and consumers.
+in their original queue. Helpers require a fresh or stopped engine with no pending
+manual tasks. Conflicting setup raises `AquteError` before consuming input. Use the
+manual API for externally managed producers and consumers.
 
 ## Buffering
 
@@ -181,6 +181,7 @@ generated. `drain_results()` removes currently available results without waiting
 also sends that signal and waits for processing. Stop producers before either
 call. These methods do not reject later submissions while the run still has work.
 `await run()` starts processing and finishes work submitted before start.
+After `run()` or `finish()` completes, await `stop()` before starting a helper.
 
 The executable [service shutdown example](service_shutdown.md) shows:
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -42,23 +42,59 @@ including custom iterators with `close()` or `aclose()` methods.
 
 Use each context and iterator once, and consume results inside the context.
 Use the engine sequentially. Before reusing it with a helper after partial
-consumption, call `drain_results()` to remove retained results. Otherwise, a helper
-can consume results from the previous run. Use a fresh engine when those results
-must remain in their original queue. Helpers own the run; use the manual API for
-externally managed producers and consumers.
+consumption, call `drain_results()` to remove retained results. Helpers reject
+retained results in an automatically created result queue. Drain supplied queues
+too; helpers consume from them. Use a fresh engine when those results must remain
+in their original queue. Helpers require no active run or pending manual tasks;
+conflicting setup raises `AquteError` before consuming input. Use the manual API
+for externally managed producers and consumers.
 
 ## Buffering
 
-Set both `input_task_queue_size=I` and `result_queue=asyncio.Queue(R)` to positive
-values to bound buffering. With `W` workers and one producer, Aqute retains at most
-`I + 2*R + W + 3` input/result items, including pending admission and the current
-yielded item. The internal worker-result queue uses capacity `R` too. Slow result
-consumption blocks further processing and admission.
+`process_all()` and `iter_results()` use finite buffering by default. With `W`
+workers, omitted limits give each queue capacity `W`: pending input, terminal
+results, and the internal worker-result queue. Slow result consumption blocks
+further processing and admission.
+
+| Constructor option | Helper runs | Manual runs |
+| --- | --- | --- |
+| Omitted `input_task_queue_size`, or `None` | Capacity `W` | Unlimited |
+| `input_task_queue_size=I`, with `I > 0` | Capacity `I` | Capacity `I` |
+| `input_task_queue_size=0` | Unlimited | Unlimited |
+| Omitted `result_queue`, or `None` | Capacity `W` per result queue | Unlimited |
+| `result_queue=asyncio.Queue(R)` | Supplied queue and relay use `R` | Supplied queue and relay use `R` |
+
+A supplied result queue keeps its identity and capacity, including explicit
+`asyncio.Queue(0)` for unlimited results. Aqute does not resize or replace it.
+After helper cleanup, manual runs keep their original queue limits and already
+published results remain available through `get_result()` or `drain_results()`.
+
+With positive input capacity `I`, result capacity `R`, and one producer, Aqute
+retains at most `I + 2*R + W + 3` input/result items, including pending admission,
+the collector-held result, and the currently yielded item. The default helper
+bound is `4*W + 3` items. The internal worker-result queue uses capacity `R` too.
 
 This is an item-count bound, not a byte limit. It excludes items retained by the
 source or caller and the growing list returned by `process_all()`. A queue size of
 zero is unlimited. Multiple independent producer calls can each hold an item
 while waiting for admission; the formula above assumes one producer.
+
+This pre-1.0 change replaces the constructor default
+`input_task_queue_size: int = 0` with `input_task_queue_size: int | None = None`.
+Existing positive capacities still override the defaults. To preserve the old
+unlimited helper behavior, set both limits explicitly:
+
+```python
+engine = Aqute(
+    handle,
+    workers_count=32,
+    input_task_queue_size=0,
+    result_queue=asyncio.Queue(0),
+)
+```
+
+Manual pre-submit-then-run and run-then-drain flows with omitted limits need no
+migration. Deprecated helper names inherit the new helper defaults.
 
 ## Concurrency, rate, and priority
 

--- a/tests/aqute/test_helper_defaults.py
+++ b/tests/aqute/test_helper_defaults.py
@@ -1,0 +1,227 @@
+import asyncio
+import contextlib
+from collections import Counter
+
+import pytest
+
+from aqute import Aqute, AquteError
+
+
+async def echo(value: int) -> int:
+    return value
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("length", [100, 1000])
+@pytest.mark.parametrize("asynchronous", [False, True])
+@pytest.mark.parametrize("explicit", [False, True])
+async def test_slow_consumer_limits_source_and_terminal_results(
+    length, asynchronous, explicit
+):
+    """Paused consumption bounds progress; resuming returns every source item."""
+    workers = 2
+    bound = (1 + 2 * 1 if explicit else 3 * workers) + workers + 3
+    produced = handled = 0
+    overflow = asyncio.Event()
+
+    def source():
+        nonlocal produced
+        for value in range(length):
+            produced += 1
+            if produced > bound:
+                overflow.set()
+            yield value
+
+    async def async_source():
+        for value in source():
+            yield value
+
+    async def handler(value: int) -> int:
+        nonlocal handled
+        handled += 1
+        return value
+
+    queue = asyncio.Queue(1) if explicit else None
+    engine = (
+        Aqute(handler, workers, input_task_queue_size=1, result_queue=queue)
+        if explicit
+        else Aqute(handler, workers)
+    )
+    items = async_source() if asynchronous else source()
+    async with asyncio.timeout(2):
+        async with engine.iter_results(items, submission_batch_size=8) as stream:
+            first = await anext(stream)
+            with pytest.raises(TimeoutError):
+                async with asyncio.timeout(0.03):
+                    await overflow.wait()
+            assert 1 <= handled <= produced <= bound
+            results = [first, *[task async for task in stream]]
+    assert Counter(task.result for task in results) == Counter(range(length))
+    assert handled == produced == length
+    if queue is not None:
+        assert engine.result_queue is queue
+        assert queue.maxsize == 1
+        async with asyncio.timeout(1):
+            await engine.add_task(length)
+            await engine.run()
+            assert queue.get_nowait().result == length
+            await engine.stop()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("capacity", [None, 1, 0])
+@pytest.mark.parametrize("collect", [False, True])
+@pytest.mark.parametrize("asynchronous", [False, True])
+async def test_input_capacity_controls_admission_before_handlers_complete(
+    capacity, collect, asynchronous
+):
+    """Finite input stops admission; explicit zero permits source exhaustion."""
+    produced = started = 0
+    workers_started = asyncio.Event()
+    exhausted = asyncio.Event()
+    release = asyncio.Event()
+
+    def source():
+        nonlocal produced
+        for value in range(40):
+            produced += 1
+            yield value
+        exhausted.set()
+
+    async def async_source():
+        for value in source():
+            yield value
+
+    async def handler(value: int) -> int:
+        nonlocal started
+        started += 1
+        if started == 2:
+            workers_started.set()
+        await release.wait()
+        return value
+
+    engine = Aqute(handler, 2, input_task_queue_size=capacity)
+
+    async def consume():
+        items = async_source() if asynchronous else source()
+        if collect:
+            return await engine.process_all(items)
+        async with engine.iter_results(items) as stream:
+            return [task async for task in stream]
+
+    operation = asyncio.create_task(consume())
+    async with asyncio.timeout(2):
+        try:
+            await workers_started.wait()
+            if capacity == 0:
+                await exhausted.wait()
+                assert produced == 40
+            else:
+                with pytest.raises(TimeoutError):
+                    async with asyncio.timeout(0.03):
+                        await exhausted.wait()
+                assert 2 <= produced <= (2 if capacity is None else capacity) + 3
+        finally:
+            release.set()
+            results = await operation
+    assert Counter(task.result for task in results) == Counter(range(40))
+
+
+@pytest.mark.asyncio
+async def test_explicit_unlimited_result_queue_keeps_all_completed_results():
+    """A supplied unlimited queue permits finishing before consuming the rest."""
+    queue = asyncio.Queue(0)
+    engine = Aqute(echo, 2, result_queue=queue)
+    exhausted = asyncio.Event()
+
+    def source():
+        yield from range(40)
+        exhausted.set()
+
+    async with asyncio.timeout(2):
+        async with engine.iter_results(source()) as stream:
+            first = await anext(stream)
+            await exhausted.wait()
+            await engine.finish()
+            assert engine.result_queue is queue
+            assert queue.maxsize == 0
+            assert queue.qsize() == 39
+            results = [first, *[task async for task in stream]]
+    assert Counter(task.result for task in results) == Counter(range(40))
+    assert engine.result_queue is queue
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("exit_mode", ["complete", "break", "error", "cancel"])
+async def test_helper_exit_retains_results_and_restores_manual_defaults(exit_mode):
+    """Every exit preserves retained results and later manual preload/drain."""
+    engine = Aqute(echo, 2)
+    exhausted = asyncio.Event()
+
+    def source():
+        yield from range(3)
+        exhausted.set()
+
+    async def consume():
+        async with engine.iter_results(source()) as stream:
+            first = await anext(stream)
+            await exhausted.wait()
+            await engine.finish()
+            if exit_mode == "complete":
+                return [first, *[task async for task in stream]]
+            if exit_mode == "error":
+                raise ValueError("consumer failed")
+            if exit_mode == "cancel":
+                raise asyncio.CancelledError
+            return [first]
+
+    async with asyncio.timeout(2):
+        if exit_mode in {"error", "cancel"}:
+            error = ValueError if exit_mode == "error" else asyncio.CancelledError
+            with pytest.raises(error):
+                await consume()
+            consumed = [0]
+        else:
+            consumed = [task.result for task in await consume()]
+        retained = engine.drain_results()
+        assert Counter([*consumed, *[task.result for task in retained]]) == Counter(
+            range(3)
+        )
+        for value in range(40):
+            await engine.add_task(value)
+        await engine.run()
+        assert Counter(task.result for task in engine.drain_results()) == Counter(
+            range(40)
+        )
+        await engine.stop()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("state", ["preloaded", "active", "retained"])
+async def test_conflicting_helper_setup_does_not_consume_or_discard_work(state):
+    """Conflicting helper setup fails before source acquisition and keeps work."""
+    acquired = []
+
+    class Source:
+        def __iter__(self):
+            acquired.append(True)
+            return iter([99])
+
+    engine = Aqute(echo, 2)
+    await engine.add_task(7)
+    if state == "active":
+        engine.start()
+    elif state == "retained":
+        await engine.run()
+        await engine.stop()
+    try:
+        with pytest.raises(AquteError):
+            await engine.process_all(Source())
+        assert acquired == []
+        async with asyncio.timeout(1):
+            if state != "retained":
+                await engine.run()
+            assert [task.result for task in engine.drain_results()] == [7]
+    finally:
+        with contextlib.suppress(asyncio.CancelledError):
+            await engine.stop()

--- a/tests/aqute/test_streaming.py
+++ b/tests/aqute/test_streaming.py
@@ -64,7 +64,7 @@ async def test_submission_batch_gives_ready_coroutines_a_turn(
 
     items = async_source() if asynchronous else source()
     options = {} if batch_size is None else {"submission_batch_size": batch_size}
-    engine = Aqute(echo, 2)
+    engine = Aqute(echo, 2, input_task_queue_size=0, result_queue=asyncio.Queue(0))
     async with asyncio.timeout(1):
         if collect:
             results = await engine.process_all(items, **options)
@@ -433,7 +433,12 @@ async def test_cancelling_helper_cleans_waiting_source(collect, consume_result):
 @pytest.mark.parametrize("batch_size", [1, 32])
 async def test_drain_retained_results_before_reusing_helper(batch_size):
     completed = asyncio.Event()
+    submitted = asyncio.Event()
     handled = []
+
+    def source():
+        yield from [1, 2, 3]
+        submitted.set()
 
     async def handler(value: int) -> int:
         handled.append(value)
@@ -444,10 +449,11 @@ async def test_drain_retained_results_before_reusing_helper(batch_size):
     engine = Aqute(handler, 2)
     async with asyncio.timeout(1):
         async with engine.iter_results(
-            [1, 2, 3], submission_batch_size=batch_size
+            source(), submission_batch_size=batch_size
         ) as results:
             first = await anext(results)
             await completed.wait()
+            await submitted.wait()
             # Waiting for the public run drains completed work into retained results.
             await engine.finish()
         retained = engine.drain_results()


### PR DESCRIPTION
`process_all()` and managed `iter_results()` now use `workers_count` items per input, result, and relay queue when limits are omitted. Slow consumers therefore apply backpressure instead of accumulating an unlimited result backlog. Manual pre-submit/run/drain flows keep unlimited defaults.

`input_task_queue_size=None` selects the automatic policy, positive values set a capacity, and `0` remains unlimited. The existing `result_queue` argument controls result capacity; supplied queues keep their identity and capacity. Helper cleanup restores manual limits and preserves published results. Usage guidance includes the pre-1.0 migration and the item-count bound; payload bytes, source/caller retention, and `process_all()`'s result list remain outside that bound.

Validation: 291 tests and installed-wheel checks passed on Python 3.11–3.14; `make check` and `make build` passed. Cold Claude review verified ownership, cleanup, public behavior, and the measurement evidence. The verified error-message and landing-page wording minors were corrected and reviewed separately.

The 81-sample qualification separates equal-capacity implementation results from default-policy effects. With equal 32-item capacities, throughput differences remained within observed variation. Against old unlimited defaults, local TCP median throughput decreased 7.97% and slow-consumer throughput decreased 3.15%. Slow-consumer peak traced allocation stayed near 124 KB from 1,000 to 10,000 inputs, versus 2.36 MB at 10,000 with old defaults. These are shared-host Python-allocation measurements, not total RSS or payload-byte guarantees. The planned worker-count capacity is retained; no tuning system or speedup claim is introduced.
