### PR TITLE
fix: reject retained results from supplied helper queues

### DIFF
--- a/aqute/engine.py
+++ b/aqute/engine.py
@@ -319,8 +319,8 @@ class Aqute(Generic[TData, TResult]):
             ValueError: If submission_batch_size is not a positive integer.
                 Validation occurs when iteration starts, before consuming input.
             AquteError: If a run is already started, manual tasks are pending,
-                or an automatically owned result queue has retained results.
-                Drain retained results before starting another helper run.
+                or the result queue has retained results. Drain retained results
+                or use a fresh engine before starting another helper run.
         """
         return contextlib.aclosing(
             self._iter_results(tasks_data, submission_batch_size=submission_batch_size)
@@ -377,9 +377,12 @@ class Aqute(Generic[TData, TResult]):
                 "before starting a helper"
             )
         original_result_queue = self.result_queue
+        if not original_result_queue.empty():
+            raise AquteError(
+                "Drain retained results or use a fresh engine "
+                "before starting a helper run"
+            )
         if self._owns_result_queue:
-            if not original_result_queue.empty():
-                raise AquteError("Drain retained results before starting a helper run")
             self.result_queue = asyncio.Queue(self._workers_count)
         self._foreman.reset(
             input_task_queue_size=(
@@ -455,6 +458,9 @@ class Aqute(Generic[TData, TResult]):
 
         Raises:
             ValueError: If submission_batch_size is not a positive integer.
+            AquteError: If a run is already started, manual tasks are pending,
+                or the result queue has retained results. Drain retained results
+                or use a fresh engine before starting another helper run.
         """
         async with self.iter_results(
             tasks_data, submission_batch_size=submission_batch_size

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -42,12 +42,21 @@ including custom iterators with `close()` or `aclose()` methods.
 
 Use each context and iterator once, and consume results inside the context.
 Use the engine sequentially. Before reusing it with a helper after partial
-consumption, call `drain_results()` to remove retained results. Helpers reject
-retained results in an automatically created result queue. Drain supplied queues
-too; helpers consume from them. Use a fresh engine when those results must remain
-in their original queue. Helpers require a fresh or stopped engine with no pending
-manual tasks. Conflicting setup raises `AquteError` before consuming input. Use the
-manual API for externally managed producers and consumers.
+consumption, retrieve all retained results. Both helpers raise `AquteError` when
+results remain in the result queue, including a caller-supplied queue. Rejection
+occurs before acquiring the new source or invoking its handler. Retained outcomes
+remain unchanged and available through `get_result()` or `drain_results()`.
+Drain them explicitly before retrying:
+
+```python
+previous_results = engine.drain_results()
+new_results = await engine.process_all(new_items)
+```
+
+The new helper run returns only its own results. Use a fresh engine when old
+results must remain in their original queue. Helpers require a fresh or stopped
+engine with no pending manual tasks. Conflicting setup raises `AquteError` before
+consuming input. Use the manual API for externally managed producers and consumers.
 
 ## Buffering
 

--- a/tests/aqute/test_helper_defaults.py
+++ b/tests/aqute/test_helper_defaults.py
@@ -225,3 +225,80 @@ async def test_conflicting_helper_setup_does_not_consume_or_discard_work(state):
     finally:
         with contextlib.suppress(asyncio.CancelledError):
             await engine.stop()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("result_capacity", [None, 2, 0])
+@pytest.mark.parametrize("collect", [False, True])
+@pytest.mark.parametrize("asynchronous", [False, True])
+async def test_helpers_reject_retained_results_until_drained(
+    result_capacity, collect, asynchronous
+):
+    """Helpers preserve old outcomes and leave new input untouched until draining."""
+    handled = []
+    acquired = []
+    exhausted = asyncio.Event()
+    old_error = ValueError("old handler failure")
+
+    async def handler(value: int) -> int:
+        handled.append(value)
+        if value == 1:
+            raise old_error
+        return value * 10
+
+    def old_source():
+        yield from range(3)
+        exhausted.set()
+
+    class Source:
+        def __iter__(self):
+            acquired.append(True)
+            return iter([4, 3])
+
+    class AsyncSource:
+        def __aiter__(self):
+            acquired.append(True)
+            return self.items()
+
+        async def items(self):
+            for value in [4, 3]:
+                yield value
+
+    queue = None if result_capacity is None else asyncio.Queue(result_capacity)
+    engine = Aqute(handler, 2, result_queue=queue)
+    source = AsyncSource() if asynchronous else Source()
+
+    async def run_helper():
+        if collect:
+            return await engine.process_all(source)
+        async with engine.iter_results(source) as results:
+            return [task async for task in results]
+
+    async with asyncio.timeout(2):
+        async with engine.iter_results(old_source()) as results:
+            first = await anext(results)
+            assert first.unwrap() == 0
+            await exhausted.wait()
+            await engine.finish()
+
+        with pytest.raises(AquteError, match="Drain retained results"):
+            await run_helper()
+        assert acquired == []
+        assert Counter(handled) == Counter([0, 1, 2])
+
+        failed = await engine.get_result()
+        assert (failed.data, failed.result, failed.success) == (1, None, False)
+        assert failed.error is old_error
+        retained = engine.drain_results()
+        assert [
+            (task.data, task.result, task.error, task.success) for task in retained
+        ] == [(2, 20, None, True)]
+
+        fresh = await run_helper()
+    assert acquired == [True]
+    assert Counter(handled) == Counter([0, 1, 2, 4, 3])
+    values = [task.unwrap() for task in fresh]
+    actual = values if collect else sorted(values)
+    expected = [40, 30] if collect else [30, 40]
+    assert actual == expected
+    assert engine.drain_results() == []


### PR DESCRIPTION
`process_all()` and managed `iter_results()` now reject retained results from caller-supplied queues before acquiring new input or invoking its handler. The existing entry guard already covered automatic queues; it now applies to every result queue. Retained outcomes stay available, and explicit draining permits a run containing only its new results.

The public regression covers both helpers, synchronous/asynchronous source acquisition, and automatic/finite/unlimited queues. Eight supplied-queue cases fail against the previous behavior; all 303 candidate tests pass. `make check`, `make build`, and the Python 3.11 installed-wheel check passed. Usage guidance shows rejection and recovery. Cold Claude and fresh documentation reviews are recorded in Zhournal. This is an entry-only guard; processing paths and queue ownership remain unchanged.
