### PR TITLE
docs: make bounded HTTP processing the flagship example

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,12 +39,31 @@ improve throughput for small tasks at the cost of result latency. The default
 preserves per-item cooperative yielding. Handlers still receive one item per call;
 configure worker concurrency and queue limits separately.
 
+## Bounded HTTP processing
+
+The [runnable HTTP example](https://insomnes.github.io/aqute/http_client/) combines
+a shared HTTPX client, four workers, an attempt-rate limiter, selected retries,
+and incremental result consumption. Its managed stream uses finite queue defaults
+and closes processing before the client. It logs each page and returns a count;
+queue limits bound items, not response bytes or data retained by your application.
+
+From a development checkout, run it without network access:
+
+```bash
+uv run --locked python -m examples.http_client
+```
+
+The example completes a transport retry, then handles a terminal HTTP error in a
+separate run. Its [source](https://github.com/insomnes/aqute/blob/main/examples/http_client.py)
+also provides an explicit path for real requests. The HTTP page includes the
+source and explains buffering overrides, retry safety, and its fail-fast policy.
+
 ## Documentation and examples
 
 The [documentation](https://insomnes.github.io/aqute/) includes the complete quickstart.
 [Usage](https://insomnes.github.io/aqute/usage/) covers bounded buffering, streaming cleanup, rate limits,
 retries, shutdown, counters, and deprecated method names. Full examples cover
-[streaming](https://insomnes.github.io/aqute/streaming/), a shared [HTTP client](https://insomnes.github.io/aqute/http_client/),
+[streaming](https://insomnes.github.io/aqute/streaming/), [bounded HTTP processing](https://insomnes.github.io/aqute/http_client/),
 and [service shutdown](https://insomnes.github.io/aqute/service_shutdown/).
 
 The [documentation source](https://github.com/insomnes/aqute/blob/main/docs/index.md) includes code directly from these

--- a/docs/http_client.md
+++ b/docs/http_client.md
@@ -1,18 +1,74 @@
-# Shared HTTP client
+# Bounded HTTP processing
 
-Use one HTTPX client for all handler calls. Transport failures are retried; HTTP
-status errors propagate to the caller. The executable demonstration uses an offline
-transport and makes no network requests. HTTPX is a development dependency only.
-Call `fetch_pages(urls)` without a transport for real requests.
+Process independent GET requests with one shared HTTPX client and a fresh Aqute
+engine per run. The example combines four workers, an attempt-rate limiter,
+selected retries, and incremental result consumption.
+
+From a development checkout, run the example offline:
 
 ```bash
 uv run --locked python -m examples.http_client
 ```
 
+The HTTP transport is the only fake. The first run fetches two pages after one
+temporary connection failure. A separate run returns HTTP 503, which the example
+reports as a terminal error. The entry point logs both page bodies and ends with
+`Results: 2 pages`. The two runs use separate clients and engines.
+
+For real requests, call `await fetch_pages(urls)` without a transport. Install
+`aqute` and `httpx` in your application environment. HTTPX is a development
+dependency in this checkout; it is not an Aqute runtime dependency.
+
+## Runnable source
+
 ```python
 --8<-- "examples/http_client.py"
 ```
 
-The retry callback is included in the [streaming example](streaming.md).
+## Limits and outcomes
 
-See [usage](usage.md) for the complete lifecycle and error contracts.
+`workers_count=4` limits occupied workers. `TokenBucketRateLimiter(max_rate=10)`
+spaces attempt admissions by at least 0.1 seconds, including retries. It permits
+one initial attempt immediately and does not permit bursts. Each client request
+uses HTTPX's five-second timeout setting.
+
+`retry_count=2` permits at most three attempts per URL. Only
+`httpx.TransportError` exceptions are selected for retries. HTTP status errors,
+including 429 and 503, are terminal in this example. The existing
+[retry callback](streaming.md) adds capped exponential backoff with jitter.
+Applications must select retryable errors and operations for their own service.
+
+Aqute yields handler failures as terminal task error values. This example calls
+`task.unwrap()` to raise the first observed error and stop the run. Already logged
+pages remain logged; the remaining URLs might not complete. The offline entry
+point catches its expected HTTP error explicitly. Inspect `task.error` instead
+when your application must record failures and continue consuming results.
+
+The managed `iter_results()` context uses finite queues by default. With four
+workers, each input and result queue has capacity four. To choose other positive
+capacities, set `input_task_queue_size=I` and `result_queue=asyncio.Queue(R)` on
+the constructor. Zero means unlimited. See [buffering](usage.md#buffering) for
+the complete item bound and override rules.
+
+`fetch_pages()` logs each successful body as it arrives and returns only a count.
+It does not build a list of bodies. HTTPX still reads each complete response into
+memory. Queue capacities bound items, not bytes; source data, payload sizes, and
+data retained by application logging or persistence remain outside that bound.
+
+## Resource and retry ownership
+
+The stream context stops the producer and workers before the shared client closes,
+including when `unwrap()` or the input source raises. `fetch_pages()` owns its
+client and any supplied transport for that call. Aqute closes started generator
+sources; callers must explicitly close other source resources. See
+[streaming cleanup](usage.md#streaming-and-cleanup) for cancellation and early exit.
+
+The inputs are URL strings that can be reused for another attempt. To repeat a
+whole run, recreate an exhausted generator or use a replayable URL collection.
+Your application owns retry safety, duplicate side effects, and durable progress.
+Replace the log statement with application-owned parsing or persistence as needed;
+a logged response does not establish a durable checkpoint.
+
+See [For coding agents](usage.md#for-coding-agents) for a compact application-usage
+guide, and [manual processing](usage.md#manual-processing-and-shutdown) for
+externally managed producers and consumers.

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,8 +31,27 @@ and iterate `results` inside the context. Both helpers accept `Iterable` and
 result.
 
 See [usage](usage.md) for buffering, cleanup, retry, timeout, and compatibility
-contracts. The executable examples cover [streaming](streaming.md), a shared
-[HTTP client](http_client.md), and [service shutdown](service_shutdown.md).
+contracts. The executable examples cover [streaming](streaming.md),
+[bounded HTTP processing](http_client.md), and [service shutdown](service_shutdown.md).
+
+## Bounded HTTP processing
+
+Start with the [HTTP example](http_client.md) to combine four workers, a shared
+HTTPX client, attempt-rate limits, selected retries, and incremental results.
+The page includes the runnable source and explains its fail-fast error policy.
+
+```bash
+uv run --locked python -m examples.http_client
+```
+
+This checkout command runs offline. It completes a transport retry, logs two
+pages, and handles a terminal HTTP error in a separate run. Each run uses a fresh
+engine and a managed stream with finite queue defaults. It returns a count instead
+of retaining every body. Queues bound items, not payload bytes or application data.
+The same source provides an explicit callable path for real requests.
+
+See [For coding agents](usage.md#for-coding-agents) for helper selection and
+application ownership rules.
 
 ## When to choose Aqute
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -287,3 +287,33 @@ explicitly await that generator's `aclose()` when stopping early. Its compatibil
 wrapper shares the same processing and cleanup path; migrate new code to the
 managed `iter_results()` form. `process_all()` keeps its coroutine signature and
 ordered list return type.
+
+## For coding agents
+
+For application code, install with `pip install aqute` and import
+`Aqute` from `aqute`. The [canonical HTTP recipe](http_client.md#runnable-source)
+also requires `httpx`; the checkout's dev group includes it. Adapt that runnable
+source instead of reconstructing the API from older examples.
+
+| Application need | API |
+| --- | --- |
+| A finite batch with an ordered result list | `await engine.process_all(items)` |
+| Results as they complete, with incremental consumption | `async with engine.iter_results(items) as results`, then iterate `results` inside the context |
+| Separate producer and consumer ownership | Follow [manual processing and shutdown](#manual-processing-and-shutdown) |
+
+- Create a fresh engine for each helper run. The stream context waits for cleanup
+  after completion, early exit, or failure. Keep the external client open around
+  that context. Aqute closes started generator sources; callers own other source
+  resources and must close them explicitly.
+- Leave queue limits omitted for finite helper defaults, with each queue sized to
+  `workers_count`. Use positive capacities to override them; zero is unlimited.
+  These are item limits. Payload bytes, caller-retained data, and the complete
+  list returned by `process_all()` are outside the bound. See [buffering](#buffering).
+- Handle each terminal task explicitly. `task.unwrap()` returns the successful
+  value, including a valid `None`, or raises its error. Inspect `task.error` or
+  `task.success` when collecting partial failures. A false or `None` result does
+  not prove failure. See [task results](#task-results).
+- Select safe retry errors and a finite retry count. Every retry acquires the
+  attempt-rate limiter again; worker count controls concurrency separately.
+  Keep inputs replayable. Applications own repeated side effects, client policy,
+  and durable progress. See [retry rules](#errors-retries-and-timeouts).

--- a/examples/http_client.py
+++ b/examples/http_client.py
@@ -7,14 +7,18 @@ from collections.abc import AsyncIterable, Iterable
 import httpx
 
 from aqute import Aqute
+from aqute.ratelimiter import TokenBucketRateLimiter
 from examples.streaming import retry_delay
+
+logger = logging.getLogger(__name__)
 
 
 async def fetch_pages(
     urls: Iterable[str] | AsyncIterable[str],
     *,
     transport: httpx.AsyncBaseTransport | None = None,
-) -> list[str]:
+) -> int:
+    """Log pages as they complete; raise the first observed terminal error."""
     async with httpx.AsyncClient(timeout=5.0, transport=transport) as client:
 
         async def fetch(url: str) -> str:
@@ -24,35 +28,51 @@ async def fetch_pages(
 
         engine = Aqute(
             fetch,
-            4,
-            input_task_queue_size=8,
-            result_queue=asyncio.Queue(8),
+            workers_count=4,
+            rate_limiter=TokenBucketRateLimiter(max_rate=10),
             retry_count=2,
             retry_delay=retry_delay,
             specific_errors_to_retry=httpx.TransportError,
         )
-        pages = []
+        completed = 0
         async with engine.iter_results(urls) as results:
             async for task in results:
-                if task.error is not None:
-                    raise task.error
-                assert task.result is not None
-                pages.append(task.result)
-        return pages
+                # Replace this log with application-owned parsing or persistence.
+                logger.info("Fetched %s: %s", task.data, task.unwrap())
+                completed += 1
+        return completed
 
 
-async def main() -> list[str]:
+async def main() -> int:
+    failed_once = False
+
     def respond(request: httpx.Request) -> httpx.Response:
+        nonlocal failed_once
+        if request.url.path == "/jobs/1" and not failed_once:
+            failed_once = True
+            raise httpx.ConnectError("temporary connection failure", request=request)
+        if request.url.path == "/unavailable":
+            return httpx.Response(503)
         return httpx.Response(200, text=request.url.path)
 
-    pages = await fetch_pages(
-        ["https://example.test/jobs/1", "https://example.test/jobs/2"],
+    completed = await fetch_pages(
+        ("https://example.test/jobs/1", "https://example.test/jobs/2"),
         transport=httpx.MockTransport(respond),
     )
-    assert sorted(pages) == ["/jobs/1", "/jobs/2"]
-    return pages
+    try:
+        await fetch_pages(
+            ("https://example.test/unavailable",),
+            transport=httpx.MockTransport(respond),
+        )
+    except httpx.HTTPStatusError as error:
+        logger.error(
+            "Terminal HTTP %s for %s; run stopped",
+            error.response.status_code,
+            error.request.url,
+        )
+    return completed
 
 
 if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO)
-    logging.info("Results: %s", sorted(asyncio.run(main())))
+    logging.info("Results: %s pages", asyncio.run(main()))

--- a/tests/examples/test_usage.py
+++ b/tests/examples/test_usage.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 import subprocess
 import sys
 from collections import Counter
@@ -14,7 +15,7 @@ from examples import http_client, service_shutdown, streaming
     [
         ("quickstart", "[0, 2, 4, 6, 8, 10, 12, 14, 16, 18]"),
         ("streaming", "[0, 2, 4, 6, 8, 10, 12, 14]"),
-        ("http_client", "['/jobs/1', '/jobs/2']"),
+        ("http_client", "2 pages"),
     ],
 )
 def test_example_entrypoint(module, expected):
@@ -34,12 +35,24 @@ async def test_streaming_example():
 
 
 @pytest.mark.asyncio
-async def test_shared_client_example():
-    assert sorted(await http_client.main()) == ["/jobs/1", "/jobs/2"]
+async def test_shared_client_example(caplog):
+    caplog.set_level(logging.INFO, logger="examples.http_client")
+    assert await http_client.main() == 2
+    messages = [
+        message
+        for name, _level, message in caplog.record_tuples
+        if name == "examples.http_client"
+    ]
+    assert sorted(messages) == [
+        "Fetched https://example.test/jobs/1: /jobs/1",
+        "Fetched https://example.test/jobs/2: /jobs/2",
+        "Terminal HTTP 503 for https://example.test/unavailable; run stopped",
+    ]
 
 
 @pytest.mark.asyncio
-async def test_http_example_retries_transport_failure():
+async def test_http_example_retries_transport_failure(caplog):
+    caplog.set_level(logging.INFO, logger="examples.http_client")
     calls = Counter()
 
     def respond(request: httpx.Request) -> httpx.Response:
@@ -48,22 +61,94 @@ async def test_http_example_retries_transport_failure():
             raise httpx.ConnectError("connection refused", request=request)
         return httpx.Response(200, text=request.url.path)
 
-    pages = await http_client.fetch_pages(
+    completed = await http_client.fetch_pages(
         ["https://example.test/jobs/1"], transport=httpx.MockTransport(respond)
     )
-    assert pages == ["/jobs/1"]
+    assert completed == 1
+    messages = [
+        message
+        for name, _level, message in caplog.record_tuples
+        if name == "examples.http_client"
+    ]
+    assert messages == ["Fetched https://example.test/jobs/1: /jobs/1"]
     assert calls == {"/jobs/1": 2}
 
 
 @pytest.mark.asyncio
 async def test_http_example_propagates_http_failure():
+    calls = 0
+
     def respond(_request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
         return httpx.Response(503)
 
     with pytest.raises(httpx.HTTPStatusError):
         await http_client.fetch_pages(
             ["https://example.test/jobs/1"], transport=httpx.MockTransport(respond)
         )
+    assert calls == 1
+
+
+class ClosingTransport(httpx.MockTransport):
+    closed = False
+
+    async def aclose(self):
+        await super().aclose()
+        self.closed = True
+
+
+@pytest.mark.asyncio
+async def test_http_failure_closes_started_source_and_client():
+    source_closed = False
+
+    async def source():
+        nonlocal source_closed
+        try:
+            yield "https://example.test/unavailable"
+            await asyncio.Event().wait()
+        finally:
+            source_closed = True
+
+    transport = ClosingTransport(lambda _request: httpx.Response(503))
+    async with asyncio.timeout(1):
+        with pytest.raises(httpx.HTTPStatusError):
+            await http_client.fetch_pages(source(), transport=transport)
+    assert source_closed
+    assert transport.closed
+
+
+@pytest.mark.asyncio
+async def test_http_source_failure_cancels_request_and_closes_client():
+    request_started = asyncio.Event()
+    request_closed = False
+    source_closed = False
+
+    async def respond(_request: httpx.Request) -> httpx.Response:
+        nonlocal request_closed
+        request_started.set()
+        try:
+            await asyncio.Event().wait()
+            return httpx.Response(200)
+        finally:
+            request_closed = True
+
+    async def source():
+        nonlocal source_closed
+        try:
+            yield "https://example.test/jobs/1"
+            await request_started.wait()
+            raise ValueError("input unavailable")
+        finally:
+            source_closed = True
+
+    transport = ClosingTransport(respond)
+    async with asyncio.timeout(1):
+        with pytest.raises(ValueError, match="input unavailable"):
+            await http_client.fetch_pages(source(), transport=transport)
+    assert request_closed
+    assert source_closed
+    assert transport.closed
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
The flagship HTTP example now consumes response bodies incrementally and returns a success count. It combines a shared HTTPX client, finite helper defaults, concurrency and attempt-rate limits, selective transport retries with capped jitter, and explicit terminal-error handling. Its offline transport demonstrates a successful retry before a separate terminal 503 run, so fail-fast cleanup cannot cancel the successful demonstration.

README and the site link to the executable source. The HTTP guide states retry safety, item-bound limits, cleanup ownership, and the example's fail-fast policy. A compact coding-agent section uses the same public API and source, with batch/stream/manual selection and valid-None result handling.

Validation: `make check`, `make build`, the Python 3.11 installed-wheel check, and `python -m examples.http_client` passed offline. Public tests cover outputs, retry selection, and source/client cleanup; only the HTTP transport is faked. Rendered source includes and local links passed inspection. Cold Claude and fresh documentation reviews are recorded in Zhournal.
