### PR TITLE
docs: separate introductory streaming from advanced policies

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -11,6 +11,7 @@ make docs
 make wheel-smoke SMOKE_PYTHON=3.11
 uv run --locked python -m examples.quickstart
 uv run --locked python -m examples.streaming
+uv run --locked python -m examples.retry_progress
 uv run --locked python -m examples.http_client
 uv run --locked python -m examples.service_shutdown
 ```
@@ -18,8 +19,9 @@ uv run --locked python -m examples.service_shutdown
 `make check` runs Ruff formatting and lint checks, ty, pytest with coverage, and a
 strict documentation build.
 The example tests verify returned values, failures, and cleanup. Entrypoint checks
-execute `quickstart`, `streaming`, and `http_client`. Commands use `uv.lock`; update dependencies with `uv lock --upgrade`
-and verify them with `make check`. CI tests Python 3.11, 3.12, 3.13, and 3.14.
+execute `quickstart`, `streaming`, `retry_progress`, and `http_client`. Commands use
+`uv.lock`; update dependencies with `uv lock --upgrade` and verify them with
+`make check`. CI tests Python 3.11, 3.12, 3.13, and 3.14.
 
 `make wheel-smoke SMOKE_PYTHON=3.14` builds a wheel, installs it without dependencies
 in a temporary virtual environment, and runs the quickstart outside the checkout.

--- a/docs/http_client.md
+++ b/docs/http_client.md
@@ -35,7 +35,7 @@ uses HTTPX's five-second timeout setting.
 `retry_count=2` permits at most three attempts per URL. Only
 `httpx.TransportError` exceptions are selected for retries. HTTP status errors,
 including 429 and 503, are terminal in this example. The existing
-[retry callback](streaming.md) adds capped exponential backoff with jitter.
+[retry callback](retry_progress.md) adds capped exponential backoff with jitter.
 Applications must select retryable errors and operations for their own service.
 
 Aqute yields handler failures as terminal task error values. This example calls

--- a/docs/retry_progress.md
+++ b/docs/retry_progress.md
@@ -1,0 +1,25 @@
+# Retry backoff and progress
+
+After the [streaming introduction](streaming.md), use this finite example to add
+selected retries and progress snapshots. One handler call fails once, then
+succeeds after capped exponential backoff with jitter. The HTTP example imports
+the same `retry_delay` callback.
+
+```bash
+uv run --locked python -m examples.retry_progress
+```
+
+```python
+--8<-- "examples/retry_progress.py"
+```
+
+`retry_count=2` permits two extra attempts. This example selects `ValueError`;
+applications must select safe retry errors and operations for their own handlers.
+See [retry rules](usage.md#errors-retries-and-timeouts) for delay and error contracts.
+
+Read `engine.counters` during iteration. Helpers stop on context exit, which resets
+the counters. See [progress counters](usage.md#progress-counters) for each field.
+
+This small example collects eight results to verify its output. Its result list
+and per-input attempt counts grow with the input length, outside Aqute's queue
+bounds. Use the introductory recipe's incremental consumption for larger inputs.

--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -1,8 +1,10 @@
-# Streaming, backoff, and progress
+# Streaming results
 
-This finite example reads asynchronous input into bounded queues. One handler
-call fails once, then succeeds after a capped retry delay with jitter. Counters
-are logged during consumption. The iterator context closes workers on early exit.
+Use streaming to process results as they complete. Start with a fresh engine and
+consume each terminal task inside the managed context. For an ordered finite batch
+or continuous manual submission, see the [API selector](usage.md#for-coding-agents).
+
+From a development checkout, run this finite example offline:
 
 ```bash
 uv run --locked python -m examples.streaming
@@ -12,4 +14,28 @@ uv run --locked python -m examples.streaming
 --8<-- "examples/streaming.py"
 ```
 
-See [usage](usage.md) for the complete lifecycle and error contracts.
+The source yields integers without building an input list. Replace `source()`
+with your iterable or async iterable, and `handle()` with your async operation.
+`task.unwrap()` returns the successful value or raises the terminal handler error.
+The loop logs each result immediately and retains no list of outputs.
+
+The example breaks after consuming three results. Context exit stops the producer
+and workers and closes the started generator source. The command logs three
+results, `Source closed`, and `Results: 3 consumed`. Results arrive in completion
+order; do not depend on input order or assume remaining inputs will complete.
+Remove the `break` condition to consume the whole finite source.
+
+Omitted queue limits give each input and result queue capacity three, matching
+`workers_count`. Slow consumption applies backpressure. These limits bound items,
+not payload bytes. Data retained by your source, logging, or application remains
+outside the bound. See [buffering](usage.md#buffering) for the complete item bound
+and capacity overrides.
+
+The context also awaits cleanup when the source or consumer raises or the caller
+is cancelled. Sources and handlers must cooperate with cancellation. Callers own
+source resources other than started generators; see
+[cleanup ownership](usage.md#streaming-and-cleanup).
+
+Continue with [retry backoff and progress](retry_progress.md) when you need retry
+policy and counter snapshots, or [bounded HTTP processing](http_client.md) for a
+shared-client recipe.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -153,7 +153,7 @@ attempts; its default is zero. `specific_errors_to_retry` selects exception type
 
 `retry_delay(failed_attempt, error)` optionally returns finite, nonnegative seconds.
 The failed-attempt number is 1-based. The callback runs only when another attempt
-is permitted. The default delay is zero. The [streaming example](streaming.md)
+is permitted. The default delay is zero. The [retry example](retry_progress.md)
 contains a capped exponential-backoff callback with jitter.
 
 A delay occupies its worker but is outside the handler timeout. Other workers can
@@ -232,8 +232,9 @@ terminal counts. `stop()` resets all counts after cleanup. Retained results do n
 become counts in a later run.
 
 Helpers stop on exit. Inspect their counters during iteration, or use the manual
-flow to inspect them after `finish()` and before `stop()`. Both the streaming and
-service examples log these snapshots.
+flow to inspect them after `finish()` and before `stop()`. The
+[retry](retry_progress.md) and [service](service_shutdown.md) examples log these
+snapshots.
 
 ## Public names and compatibility
 
@@ -307,8 +308,8 @@ source instead of reconstructing the API from older examples.
 | Application need | API |
 | --- | --- |
 | A finite batch with an ordered result list | `await engine.process_all(items)` |
-| Results as they complete, with incremental consumption | `async with engine.iter_results(items) as results`, then iterate `results` inside the context |
-| Separate producer and consumer ownership | Follow [manual processing and shutdown](#manual-processing-and-shutdown) |
+| Results in completion order, with bounded buffering and incremental consumption | `async with engine.iter_results(items) as results`, then iterate `results` inside the context |
+| Continuous submission with separate producer and consumer ownership | Follow [manual processing and shutdown](#manual-processing-and-shutdown) |
 
 - Create a fresh engine for each helper run. The stream context waits for cleanup
   after completion, early exit, or failure. Keep the external client open around

--- a/examples/http_client.py
+++ b/examples/http_client.py
@@ -8,7 +8,7 @@ import httpx
 
 from aqute import Aqute
 from aqute.ratelimiter import TokenBucketRateLimiter
-from examples.streaming import retry_delay
+from examples.retry_progress import retry_delay
 
 logger = logging.getLogger(__name__)
 

--- a/examples/retry_progress.py
+++ b/examples/retry_progress.py
@@ -1,0 +1,63 @@
+"""Bounded asynchronous input, retries, and progress counters."""
+
+import asyncio
+import logging
+from collections import Counter
+from random import uniform
+
+from aqute import Aqute
+
+logger = logging.getLogger(__name__)
+FAIL_ONCE = 3
+
+
+def retry_delay(failed_attempt: int, _error: Exception) -> float:
+    ceiling = min(5.0, 0.01 * 2 ** min(failed_attempt - 1, 10))
+    return uniform(0.0, ceiling)
+
+
+async def main() -> list[int]:
+    attempts: Counter[int] = Counter()
+
+    async def source():
+        for value in range(8):
+            yield value
+
+    async def handle(value: int) -> int:
+        attempts[value] += 1
+        if value == FAIL_ONCE and attempts[value] == 1:
+            raise ValueError("transient example failure")
+        return value * 2
+
+    engine = Aqute(
+        handle,
+        3,
+        input_task_queue_size=4,
+        result_queue=asyncio.Queue(4),
+        retry_count=2,
+        retry_delay=retry_delay,
+        specific_errors_to_retry=ValueError,
+    )
+    values = []
+    async with engine.iter_results(source()) as results:
+        async for task in results:
+            if task.error is not None:
+                raise task.error
+            assert task.result is not None
+            values.append(task.result)
+            counts = engine.counters
+            logger.info(
+                "Pending=%s running=%s succeeded=%s failed=%s retries=%s",
+                counts.pending,
+                counts.running,
+                counts.succeeded,
+                counts.failed,
+                counts.retries,
+            )
+    assert sorted(values) == [value * 2 for value in range(8)]
+    return values
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    logging.info("Results: %s", sorted(asyncio.run(main())))

--- a/examples/streaming.py
+++ b/examples/streaming.py
@@ -1,63 +1,38 @@
-"""Bounded asynchronous input, retries, and progress counters."""
+"""Consume bounded streaming results and stop early with managed cleanup."""
 
 import asyncio
 import logging
-from collections import Counter
-from random import uniform
 
 from aqute import Aqute
 
 logger = logging.getLogger(__name__)
-FAIL_ONCE = 3
+RESULT_LIMIT = 3
 
 
-def retry_delay(failed_attempt: int, _error: Exception) -> float:
-    ceiling = min(5.0, 0.01 * 2 ** min(failed_attempt - 1, 10))
-    return uniform(0.0, ceiling)
-
-
-async def main() -> list[int]:
-    attempts: Counter[int] = Counter()
-
+async def main() -> int:
     async def source():
-        for value in range(8):
-            yield value
+        try:
+            for value in range(100):
+                yield value
+        finally:
+            logger.info("Source closed")
 
     async def handle(value: int) -> int:
-        attempts[value] += 1
-        if value == FAIL_ONCE and attempts[value] == 1:
-            raise ValueError("transient example failure")
         return value * 2
 
-    engine = Aqute(
-        handle,
-        3,
-        input_task_queue_size=4,
-        result_queue=asyncio.Queue(4),
-        retry_count=2,
-        retry_delay=retry_delay,
-        specific_errors_to_retry=ValueError,
-    )
-    values = []
+    engine = Aqute(handle, workers_count=3)
+    completed = 0
     async with engine.iter_results(source()) as results:
         async for task in results:
-            if task.error is not None:
-                raise task.error
-            assert task.result is not None
-            values.append(task.result)
-            counts = engine.counters
-            logger.info(
-                "Pending=%s running=%s succeeded=%s failed=%s retries=%s",
-                counts.pending,
-                counts.running,
-                counts.succeeded,
-                counts.failed,
-                counts.retries,
-            )
-    assert sorted(values) == [value * 2 for value in range(8)]
-    return values
+            # Replace this log with application-owned processing or persistence.
+            logger.info("Result for %s: %s", task.data, task.unwrap())
+            completed += 1
+            if completed == RESULT_LIMIT:
+                break
+    # Context exit has awaited producer and worker cleanup.
+    return completed
 
 
 if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO)
-    logging.info("Results: %s", sorted(asyncio.run(main())))
+    logging.info("Results: %s consumed", asyncio.run(main()))

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,6 +8,7 @@ nav:
   - Quickstart: index.md
   - Usage: usage.md
   - Streaming: streaming.md
+  - Retry and progress: retry_progress.md
   - HTTP client: http_client.md
   - Service shutdown: service_shutdown.md
   - Development: development.md

--- a/tests/examples/test_usage.py
+++ b/tests/examples/test_usage.py
@@ -7,14 +7,15 @@ from collections import Counter
 import httpx
 import pytest
 
-from examples import http_client, service_shutdown, streaming
+from examples import http_client, retry_progress, service_shutdown, streaming
 
 
 @pytest.mark.parametrize(
     ("module", "expected"),
     [
         ("quickstart", "[0, 2, 4, 6, 8, 10, 12, 14, 16, 18]"),
-        ("streaming", "[0, 2, 4, 6, 8, 10, 12, 14]"),
+        ("streaming", "3 consumed"),
+        ("retry_progress", "[0, 2, 4, 6, 8, 10, 12, 14]"),
         ("http_client", "2 pages"),
     ],
 )
@@ -30,8 +31,25 @@ def test_example_entrypoint(module, expected):
 
 
 @pytest.mark.asyncio
-async def test_streaming_example():
-    assert sorted(await streaming.main()) == [value * 2 for value in range(8)]
+async def test_streaming_example(caplog):
+    """The example must emit three doubled values and close its source on exit."""
+    caplog.set_level(logging.INFO, logger="examples.streaming")
+    assert await streaming.main() == 3
+    messages = [
+        message
+        for name, _level, message in caplog.record_tuples
+        if name == "examples.streaming"
+    ]
+    assert messages.count("Source closed") == 1
+    results = [message for message in messages if message != "Source closed"]
+    assert len(results) == len(set(results)) == 3
+    assert set(results) <= {f"Result for {value}: {value * 2}" for value in range(100)}
+
+
+@pytest.mark.asyncio
+async def test_retry_progress_example():
+    """The advanced recipe must still return all eight values after retrying."""
+    assert sorted(await retry_progress.main()) == [value * 2 for value in range(8)]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
The introductory streaming recipe mixed result consumption with retries, injected failures and progress counters. It now uses a fresh engine with finite defaults, consumes three results through the managed context, and shows source cleanup on early exit.

The existing advanced source moves unchanged to a separate retry/progress recipe. HTTP imports, source includes, navigation and the API selector follow that move.

Validation: `env -u VIRTUAL_ENV make check` passed 307 tests, Ruff, ty and strict docs; `make build` and the streaming, retry/progress and HTTP offline entrypoints passed. Cold Claude review: LGTM with minors; no upheld defect. The optional landing-page enumeration does not affect correct use. A fresh documentation audit verified no changes were needed: 120 local links resolve and rendered source includes match. All PR checks passed, including Python 3.11–3.14.
