### PR TITLE
docs: use Material for MkDocs and clarify usage contracts

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -33,6 +33,8 @@ Release CI checks the candidate, sets its version from the published GitHub rele
 tag (optional `v` prefix), builds with `uv_build`, and publishes through GitHub's
 trusted PyPI identity. See [LICENSE](https://github.com/insomnes/aqute/blob/main/LICENSE).
 
+The site uses [Material for MkDocs](https://squidfunk.github.io/mkdocs-material/)
+with system fonts. Its dependencies are included in the locked development environment.
 Run commands from the repository root. `make docs` builds the site in `site/`;
 `uv run --locked mkdocs serve` provides a local preview at
 `http://127.0.0.1:8000/aqute/`. The documentation includes the actual files in

--- a/docs/http_client.md
+++ b/docs/http_client.md
@@ -19,6 +19,13 @@ For real requests, call `await fetch_pages(urls)` without a transport. Install
 `aqute` and `httpx` in your application environment. HTTPX is a development
 dependency in this checkout; it is not an Aqute runtime dependency.
 
+The source imports `retry_delay` from the checkout's `examples.retry_progress`,
+which is not installed with `aqute`. To adapt it outside the checkout, copy the
+callback and its `from random import uniform` import from the
+[retry recipe](retry_progress.md), or provide your own callback. Replace the
+`examples.retry_progress` import with your application's import, or remove it if
+you define the callback in the same file.
+
 ## Runnable source
 
 ```python

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -105,6 +105,12 @@ engine = Aqute(
 Manual pre-submit-then-run and run-then-drain flows with omitted limits need no
 migration. Deprecated helper names inherit the new helper defaults.
 
+Helpers now reject pending manual tasks, so preloading with `add_task()` before
+`process_all()` or `iter_results()` raises `AquteError`. Follow
+[manual processing and shutdown](#manual-processing-and-shutdown) to finish the
+work while draining results, then stop the engine before using a helper.
+Alternatively, use a separate fresh engine for the helper.
+
 ## Concurrency, rate, and priority
 
 `workers_count` limits occupied workers. It does not specify requests per second.
@@ -149,6 +155,8 @@ worker. A worker retains its task through retries.
 
 Handler exceptions become `AquteTask.error` values. `retry_count` specifies extra
 attempts; its default is zero. `specific_errors_to_retry` selects exception types.
+When omitted, it defaults to `None`: every caught handler error is eligible while
+the retry budget remains.
 `errors_to_not_retry` excludes types and takes precedence when both filters match.
 
 `retry_delay(failed_attempt, error)` optionally returns finite, nonnegative seconds.
@@ -301,7 +309,7 @@ ordered list return type.
 ## For coding agents
 
 For application code, install with `pip install aqute` and import
-`Aqute` from `aqute`. The [canonical HTTP recipe](http_client.md#runnable-source)
+`Aqute` from `aqute`. The [canonical HTTP recipe](http_client.md)
 also requires `httpx`; the checkout's dev group includes it. Adapt that runnable
 source instead of reconstructing the API from older examples.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,7 +3,9 @@ site_url: https://insomnes.github.io/aqute/
 site_description: Async coroutine processing with bounded queues, retries, and rate limits.
 repo_url: https://github.com/insomnes/aqute
 edit_uri: edit/main/docs/
-theme: mkdocs
+theme:
+  name: material
+  font: false
 nav:
   - Quickstart: index.md
   - Usage: usage.md
@@ -14,7 +16,8 @@ nav:
   - Development: development.md
 markdown_extensions:
   - tables
-  - fenced_code
+  - pymdownx.highlight
+  - pymdownx.superfences
   - pymdownx.snippets:
       base_path: ["."]
       check_paths: true

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,6 +6,8 @@ edit_uri: edit/main/docs/
 theme:
   name: material
   font: false
+  features:
+    - content.action.edit
 nav:
   - Quickstart: index.md
   - Usage: usage.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dev = [
     "genbadge[coverage]>=1.1,<2",
     "httpx>=0.28,<1",
     "mkdocs>=1.6,<2",
+    "mkdocs-material>=9.7,<10",
     "pymdown-extensions>=10,<11",
     "pytest>=8.3.2,<10",
     "pytest-asyncio>=1.0,<2",

--- a/uv.lock
+++ b/uv.lock
@@ -26,6 +26,7 @@ dev = [
     { name = "genbadge", extra = ["coverage"] },
     { name = "httpx" },
     { name = "mkdocs" },
+    { name = "mkdocs-material" },
     { name = "pymdown-extensions" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -41,11 +42,34 @@ dev = [
     { name = "genbadge", extras = ["coverage"], specifier = ">=1.1,<2" },
     { name = "httpx", specifier = ">=0.28,<1" },
     { name = "mkdocs", specifier = ">=1.6,<2" },
+    { name = "mkdocs-material", specifier = ">=9.7,<10" },
     { name = "pymdown-extensions", specifier = ">=10,<11" },
     { name = "pytest", specifier = ">=8.3.2,<10" },
     { name = "pytest-asyncio", specifier = ">=1.0,<2" },
     { name = "ruff", specifier = ">=0.15,<0.16" },
     { name = "ty", specifier = ">=0.0.1,<0.1" },
+]
+
+[[package]]
+name = "babel"
+version = "2.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/b2/51899539b6ceeeb420d40ed3cd4b7a40519404f9baf3d4ac99dc413a834b/babel-2.18.0.tar.gz", hash = "sha256:b80b99a14bd085fcacfa15c9165f651fbb3406e66cc603abf11c5750937c992d", size = 9959554, upload-time = "2026-02-01T12:30:56.078Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/f5/21d2de20e8b8b0408f0681956ca2c69f1320a3848ac50e6e7f39c6159675/babel-2.18.0-py3-none-any.whl", hash = "sha256:e2b422b277c2b9a9630c1d7903c2a00d0830c409c59ac8cae9081c92f1aeba35", size = 10196845, upload-time = "2026-02-01T12:30:53.445Z" },
+]
+
+[[package]]
+name = "backrefs"
+version = "8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ec/56/4744bcd0c82184e80c52b0ac4076c261a8ffa1f1b343ff2f6e89ce0e1cef/backrefs-8.0.tar.gz", hash = "sha256:b556cd7d36c3a3a2f256b89590b176b8eddfb73bcfaee3a3ddd84ea66d21ce50", size = 7013081, upload-time = "2026-07-26T19:54:24.638Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e3/fd/9bf53b6a6f6f519ffaac765df2f2a25e5c2fc6d32cfd2b2747099e72c911/backrefs-8.0-py310-none-any.whl", hash = "sha256:4a627b817fd2dce43b79ab48da63613340509381cd8ce0897078a0bce79a2ab8", size = 380377, upload-time = "2026-07-26T19:54:17.457Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/29/4bd7ae72a2634da00379c2b3bcc5439e7c94620235c6afea8af15229a973/backrefs-8.0-py311-none-any.whl", hash = "sha256:f0c35cf0102ba6b6070c12a492be3c1c1d3f5839529784b9a9565d6d04569a01", size = 392169, upload-time = "2026-07-26T19:54:18.782Z" },
+    { url = "https://files.pythonhosted.org/packages/29/13/232505664e8e2a0c7a2eb0c505cfade9d715538f89a5d62bc4c272968f62/backrefs-8.0-py312-none-any.whl", hash = "sha256:87f0fae8c5f207fe9f4b2887efc71d42f4900ac78faa1af08d675ef303692dc5", size = 398084, upload-time = "2026-07-26T19:54:19.954Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/69/47a3dc20abc4fa5486655fde681bd55e63211b46c886d8c02223d6468431/backrefs-8.0-py313-none-any.whl", hash = "sha256:601ce68ca12385dbda06ce264406b4c4210cf5b79fd0fd627592365c92f29a88", size = 400040, upload-time = "2026-07-26T19:54:21.194Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/cf/e5f9b68a5b0e939a2fb933a66c20180d0c9241bf8927f7a47fa48c1675e9/backrefs-8.0-py314-none-any.whl", hash = "sha256:9ec96efa080938be92323e8e730e57718c9c88eb15ad70bbef4e1766df591408", size = 411903, upload-time = "2026-07-26T19:54:23.221Z" },
 ]
 
 [[package]]
@@ -575,12 +599,52 @@ wheels = [
 ]
 
 [[package]]
+name = "mkdocs-material"
+version = "9.7.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "babel" },
+    { name = "backrefs" },
+    { name = "colorama" },
+    { name = "jinja2" },
+    { name = "markdown" },
+    { name = "mkdocs" },
+    { name = "mkdocs-material-extensions" },
+    { name = "paginate" },
+    { name = "pygments" },
+    { name = "pymdown-extensions" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f1/cd/c05d3a530ba7934f144fb45f7203cd236adc25c7bdcc34673d202f4b0278/mkdocs_material-9.7.7.tar.gz", hash = "sha256:c0649c065b1b0512d60aad8c10f947f8e455284475239b364b610f2deb4d0855", size = 4097923, upload-time = "2026-07-17T16:21:33.156Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ad/21/17c1bc9e6f47c972ad66fb2ac2568f99f90f1207eeb6fc3b34d094dba7b5/mkdocs_material-9.7.7-py3-none-any.whl", hash = "sha256:8ea9bb1737a5b524a5f9dcf2e1b4ebda8274ae3008aa7845720a97083bef708f", size = 9305438, upload-time = "2026-07-17T16:21:30.017Z" },
+]
+
+[[package]]
+name = "mkdocs-material-extensions"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/79/9b/9b4c96d6593b2a541e1cb8b34899a6d021d208bb357042823d4d2cabdbe7/mkdocs_material_extensions-1.3.1.tar.gz", hash = "sha256:10c9511cea88f568257f960358a467d12b970e1f7b2c0e5fb2bb48cab1928443", size = 11847, upload-time = "2023-11-22T19:09:45.208Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5b/54/662a4743aa81d9582ee9339d4ffa3c8fd40a4965e033d77b9da9774d3960/mkdocs_material_extensions-1.3.1-py3-none-any.whl", hash = "sha256:adff8b62700b25cb77b53358dad940f3ef973dd6db797907c49e3c2ef3ab4e31", size = 8728, upload-time = "2023-11-22T19:09:43.465Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.3"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/7d/fa/3944b40b07da9ce895c0e6303a5ab7d53da063554f534556b134a54d6093/packaging-26.3.tar.gz", hash = "sha256:94edc256424af38762eb31306eed28beb9f0efc50a8837492c9d6fd6004aed79", size = 313412, upload-time = "2026-08-04T18:15:28.737Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/63/34/ba1c580383c9eada3711951fef0795c80b829a078d72188184bcab9dd527/packaging-26.3-py3-none-any.whl", hash = "sha256:d7193f7c8e4e93f444fde0262bf90af30e16fa0ad0ad44cb553c87339b23cd1c", size = 129956, upload-time = "2026-08-04T18:15:27.159Z" },
+]
+
+[[package]]
+name = "paginate"
+version = "0.5.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ec/46/68dde5b6bc00c1296ec6466ab27dddede6aec9af1b99090e1107091b3b84/paginate-0.5.7.tar.gz", hash = "sha256:22bd083ab41e1a8b4f3690544afb2c60c25e5c9a63a30fa2f483f6c60c8e5945", size = 19252, upload-time = "2024-08-25T14:17:24.139Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/90/96/04b8e52da071d28f5e21a805b19cb9390aa17a47462ac87f5e2696b9566d/paginate-0.5.7-py2.py3-none-any.whl", hash = "sha256:b885e2af73abcf01d9559fd5216b57ef722f8c42affbb63942377668e35c7591", size = 13746, upload-time = "2024-08-25T14:17:22.55Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Use Material for MkDocs 9.7.7 with system fonts, highlighted runnable examples and per-page edit controls. Lock the development tooling and preserve the existing URLs, navigation, search and GitHub Pages workflow.

Clarify omitted retry-filter defaults, adapting the HTTP callback outside the checkout, and migration from preloaded manual tasks to helpers.

