### PR TITLE
fix: backport rate limiter corrections for 0.9.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
+        python-version: ["3.9", "3.10"]
         command:
         - "ruff check ."
         - "ruff format --check ."
@@ -23,11 +24,11 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: 3.9
+        python-version: ${{ matrix.python-version }}
 
     - name: Install Poetry
       run: |
-        curl -sSL https://install.python-poetry.org | python3 -
+        python -m pip install poetry==1.8.3
 
     - name: Install dependencies
       run: make install
@@ -36,4 +37,3 @@ jobs:
       run: |
         source $(poetry env info --path)/bin/activate
         ${{ matrix.command }}
-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - maintenance/0.9.x
   pull_request:
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ You can also add RateLimiter instance to Aqute for rate limiting:
     assert len(result) == len(input_data)
 ```
 
-There are three available `RateLimiter` implementations:
+There are four available `RateLimiter` implementations:
 - `TokenBucketRateLimiter`: steady rate by default, burstable with `allow_burst` option;
 - `SlidingRateLimiter`: next call will be available after enough time from the oldest one;
 - `PerWorkerRateLimiter`: enforces separate rate limits for each unique worker with separate `TokenBucketRateLimiter` instances;

--- a/aqute/ratelimiter.py
+++ b/aqute/ratelimiter.py
@@ -29,16 +29,17 @@ class TokenBucketRateLimiter:
 
         This rate limiter employs the token bucket technique where tokens are added
         to the bucket at a certain rate up to the bucket's capacity. An action consumes
-        a token from the bucket.
+        a token from the bucket. The bucket starts full, and idle time cannot increase
+        its capacity.
 
         Args:
-            max_rate: Maximum rate at which tokens are added to the bucket per second.
-            time_period (optional): Period in seconds over which max_rate is measured.
-                Defaults to 1 second.
-            allow_burst (optional): allow to burst requests if bucket capacity is
-                available.
+            max_rate: Number of tokens added per time_period.
+            time_period (optional): Finite positive period in seconds over which
+                max_rate is measured. Defaults to 1 second.
+            allow_burst (optional): If True, capacity is max_rate tokens. Otherwise,
+                capacity is one token, enforcing time_period / max_rate between grants.
         """
-        if max_rate < 1 or time_period <= 0:
+        if max_rate < 1 or not 0 < time_period < math.inf:
             raise ValueError(
                 f"Invalid values for configuration: {max_rate=}, {time_period=}"
             )
@@ -73,11 +74,12 @@ class TokenBucketRateLimiter:
                 Defaults to None for protocol compatibility.
         """
         async with self._lock:
+            self._refill_tokens()
             while self._tokens < 1:
-                self._refill_tokens()
                 sleep_time = (1 - self._tokens) / self._fill_rate
                 logger.debug(f"Got {sleep_time:.5f} <{name}>")
                 await asyncio.sleep(sleep_time)
+                self._refill_tokens()
             self._tokens -= 1
 
 
@@ -91,10 +93,10 @@ class SlidingRateLimiter:
 
         Args:
             max_rate: Maximum allowable actions within the time period.
-            time_period (optional): Period in seconds for rate measurement. Defaults
-                to 1 second.
+            time_period (optional): Finite positive period in seconds for rate
+                measurement. Defaults to 1 second.
         """
-        if max_rate < 1 or time_period <= 0:
+        if max_rate < 1 or not 0 < time_period < math.inf:
             raise ValueError(
                 f"Invalid values for configuration: {max_rate=}, {time_period=}"
             )
@@ -142,10 +144,10 @@ class PerWorkerRateLimiter:
 
         Args:
             max_rate: Maximum allowable actions within the time period.
-            time_period (optional): Period in seconds for rate measurement. Defaults
-                to 1 second.
+            time_period (optional): Finite positive period in seconds for rate
+                measurement. Defaults to 1 second.
         """
-        if max_rate < 1 or time_period <= 0:
+        if max_rate < 1 or not 0 < time_period < math.inf:
             raise ValueError(
                 f"Invalid values for configuration: {max_rate=}, {time_period=}"
             )
@@ -192,8 +194,8 @@ class RandomizedIntervalRateLimiter:
 
         Args:
             max_rate: Maximum allowable actions within the time period.
-            time_period (optional): Period in seconds for rate measurement. Defaults
-                to 1 second.
+            time_period (optional): Finite positive period in seconds for rate
+                measurement. Defaults to 1 second.
             mean_target_multiplier (optional): The mean multiplier influencing
                 the average sleep duration.
             std_dev (optional): The standard deviation for the Gaussian distribution,
@@ -205,7 +207,7 @@ class RandomizedIntervalRateLimiter:
             lower_upper_fluctuation (optional): The fluctuation margin for the
                 multiplier bounds, adding variability when bounds are reached.
         """
-        if max_rate < 1 or time_period <= 0:
+        if max_rate < 1 or not 0 < time_period < math.inf:
             raise ValueError(
                 f"Invalid values for configuration: {max_rate=}, {time_period=}"
             )

--- a/tests/rate_limiter/test_configuration.py
+++ b/tests/rate_limiter/test_configuration.py
@@ -1,0 +1,26 @@
+import pytest
+
+from aqute.ratelimiter import (
+    PerWorkerRateLimiter,
+    RandomizedIntervalRateLimiter,
+    SlidingRateLimiter,
+    TokenBucketRateLimiter,
+)
+
+
+@pytest.mark.parametrize(
+    "limiter_class",
+    [
+        TokenBucketRateLimiter,
+        SlidingRateLimiter,
+        PerWorkerRateLimiter,
+        RandomizedIntervalRateLimiter,
+    ],
+)
+@pytest.mark.parametrize(
+    "time_period", [0, -1, float("nan"), float("inf"), -float("inf")]
+)
+def test_invalid_time_period(limiter_class, time_period):
+    """Reject invalid periods before the limiter can accept work."""
+    with pytest.raises(ValueError):
+        limiter_class(1, time_period)

--- a/tests/rate_limiter/test_token_bucket_rate_limiter.py
+++ b/tests/rate_limiter/test_token_bucket_rate_limiter.py
@@ -68,6 +68,36 @@ async def test_bursting():
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("allow_burst", "acquired_before_idle"),
+    [
+        pytest.param(False, 0, id="delayed-first-use-no-burst"),
+        pytest.param(True, 0, id="delayed-first-use-burst"),
+        pytest.param(True, 1, id="partially-full-before-idle"),
+    ],
+)
+async def test_idle_does_not_increase_capacity(allow_burst, acquired_before_idle):
+    """An idle bucket grants its capacity, then waits for the next token."""
+    max_rate = 4
+    time_period = 0.2
+    capacity = max_rate if allow_burst else 1
+    limiter = TokenBucketRateLimiter(max_rate, time_period, allow_burst)
+
+    for _ in range(acquired_before_idle):
+        await limiter.acquire()
+    await asyncio.sleep(time_period + 0.05)
+
+    granted_at = []
+    start = perf_counter()
+    for _ in range(capacity + 1):
+        await limiter.acquire()
+        granted_at.append(perf_counter())
+
+    assert granted_at[capacity - 1] - start < time_period / max_rate
+    assert granted_at[capacity] - granted_at[0] >= time_period / max_rate - 0.001
+
+
+@pytest.mark.asyncio
 async def test_simultaneous_acquisitions():
     """
     Eleventh request should wait at least 0.4 seconds if we have rate for 5 requests


### PR DESCRIPTION
Backport the token-bucket idle-refill fix and finite positive `time_period` validation onto 0.9.2 for the 0.9.3 maintenance line. Idle time no longer permits grants above bucket capacity. All four rate limiters reject invalid periods at construction.

Preserve Python 3.9/3.10 support, public APIs, existing buffering behavior, and Poetry packaging.
