### PR TITLE
feat!: remove deprecated method aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,47 @@
+# Changelog
+
+## Unreleased
+
+### Breaking changes from 0.9.2
+
+Python 3.11 or newer is required. The
+[0.9.x maintenance branch](https://github.com/insomnes/aqute/tree/maintenance/0.9.x)
+retains Python 3.9/3.10 support and the old method names.
+
+The public API uses one method set. The old names are removed without
+compatibility wrappers; rename calls during the upgrade:
+
+| 0.9.2 call | Replacement |
+| --- | --- |
+| `engine.set_all_tasks_added()` | `engine.finish_submitting()` |
+| `await engine.wait_till_end()` | `await engine.finish()` |
+| `await engine.start_and_wait()` | `await engine.run()` |
+| `await engine.get_task_result()` | `await engine.get_result()` |
+| `engine.extract_all_results()` | `engine.drain_results()` |
+| `await engine.apply_to_all(items)` | `await engine.process_all(items)` |
+| `engine.apply_to_each(items)` | `async with engine.iter_results(items) as results` |
+
+Streaming requires an async context. Iterate its yielded iterator inside that
+context so exit awaits producer and worker cleanup, including after early exit:
+
+```python
+async with engine.iter_results(items) as results:
+    async for task in results:
+        consume(task)
+```
+
+Helper and manual runs now use finite input and result queues by default, each
+with capacity `workers_count`. Omitted limits and `None` use this capacity;
+positive limits and explicit zero keep their meaning. Manual runs must consume
+results concurrently or explicitly choose unlimited buffering. For
+pre-submit-then-run with results drained after completion, set both
+`input_task_queue_size=0` and `result_queue=asyncio.Queue(0)`. For run-then-drain,
+only the result queue must be unlimited. Before processing starts, `add_task()`
+raises `AquteError` when the input queue is full. With finite result queues and no
+concurrent consumer, submission or completion can wait indefinitely. See
+[queue-default migration](https://insomnes.github.io/aqute/usage/#queue-default-migration).
+
+`process_all()` still retains the complete result list. Helpers reject pending
+manual tasks and unconsumed results; finish manual work and drain results before
+reusing a stopped engine, or use a fresh engine. See
+[buffering and migration](https://insomnes.github.io/aqute/usage/#buffering).

--- a/README.md
+++ b/README.md
@@ -69,7 +69,8 @@ source and explains buffering overrides, retry safety, and its fail-fast policy.
 
 The [documentation](https://insomnes.github.io/aqute/) includes the complete quickstart.
 [Usage](https://insomnes.github.io/aqute/usage/) covers bounded buffering, streaming cleanup, rate limits,
-retries, shutdown, counters, and deprecated method names. Full examples cover
+retries, shutdown, counters, and migration from 0.9.2. The
+[changelog](CHANGELOG.md) collects the breaking changes and method renames. Full examples cover
 [streaming](https://insomnes.github.io/aqute/streaming/), [bounded HTTP processing](https://insomnes.github.io/aqute/http_client/),
 [manual result draining](https://insomnes.github.io/aqute/manual_drain/),
 and [service shutdown](https://insomnes.github.io/aqute/service_shutdown/).

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ source and explains buffering overrides, retry safety, and its fail-fast policy.
 The [documentation](https://insomnes.github.io/aqute/) includes the complete quickstart.
 [Usage](https://insomnes.github.io/aqute/usage/) covers bounded buffering, streaming cleanup, rate limits,
 retries, shutdown, counters, and migration from 0.9.2. The
-[changelog](CHANGELOG.md) collects the breaking changes and method renames. Full examples cover
+[changelog](https://github.com/insomnes/aqute/blob/main/CHANGELOG.md) collects the breaking changes and method renames. Full examples cover
 [streaming](https://insomnes.github.io/aqute/streaming/), [bounded HTTP processing](https://insomnes.github.io/aqute/http_client/),
 [manual result draining](https://insomnes.github.io/aqute/manual_drain/),
 and [service shutdown](https://insomnes.github.io/aqute/service_shutdown/).

--- a/aqute/engine.py
+++ b/aqute/engine.py
@@ -1,7 +1,6 @@
 import asyncio
 import contextlib
 import logging
-import warnings
 from collections.abc import (
     AsyncGenerator,
     AsyncIterable,
@@ -638,73 +637,3 @@ class Aqute(Generic[TData, TResult]):
         tb: TracebackType | None,
     ) -> None:
         await self.stop()
-
-    def set_all_tasks_added(self) -> None:
-        """Deprecated; use finish_submitting()."""
-        warnings.warn(
-            "set_all_tasks_added() is deprecated; use finish_submitting()",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        self.finish_submitting()
-
-    async def wait_till_end(self) -> None:
-        """Deprecated; use finish()."""
-        warnings.warn(
-            "wait_till_end() is deprecated; use finish()",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        await self.finish()
-
-    async def start_and_wait(self) -> None:
-        """Deprecated; use run()."""
-        warnings.warn(
-            "start_and_wait() is deprecated; use run()",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        await self.run()
-
-    async def get_task_result(self) -> AquteTask[TData, TResult]:
-        """Deprecated; use get_result()."""
-        warnings.warn(
-            "get_task_result() is deprecated; use get_result()",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return await self.get_result()
-
-    def extract_all_results(self) -> list[AquteTask[TData, TResult]]:
-        """Deprecated; use drain_results()."""
-        warnings.warn(
-            "extract_all_results() is deprecated; use drain_results()",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self.drain_results()
-
-    async def apply_to_all(
-        self, tasks_data: Iterable[TData] | AsyncIterable[TData]
-    ) -> list[AquteTask[TData, TResult]]:
-        """Deprecated; use process_all()."""
-        warnings.warn(
-            "apply_to_all() is deprecated; use process_all()",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return await self.process_all(tasks_data)
-
-    def apply_to_each(
-        self, tasks_data: Iterable[TData] | AsyncIterable[TData]
-    ) -> AsyncGenerator[AquteTask[TData, TResult]]:
-        """Deprecated generator API; close partial iteration with aclose/aclosing.
-
-        Prefer ``async with engine.iter_results(items) as results`` in new code.
-        """
-        warnings.warn(
-            "apply_to_each() is deprecated; use iter_results()",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self._iter_results(tasks_data)

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -306,8 +306,8 @@ snapshots.
 
 ## Migration from 0.9.2
 
-The next breaking release removes the old method names without compatibility
-wrappers. Update calls when upgrading from 0.9.2:
+The old method names are removed without compatibility wrappers. Update calls
+when upgrading from 0.9.2:
 
 | 0.9.2 call | Replacement |
 | --- | --- |

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -116,7 +116,7 @@ Run-then-drain starts processing before submission and needs only
 `result_queue=asyncio.Queue(0)`; the input queue can keep its default capacity.
 See the [manual drain example](manual_drain.md). With finite result queues and no
 concurrent consumer, `add_task()` or `finish()` can wait indefinitely. Aqute does
-not detect this arrangement. Deprecated methods use the same queue defaults.
+not detect this arrangement.
 
 Helpers now reject pending manual tasks, so preloading with `add_task()` before
 `process_all()` or `iter_results()` raises `AquteError`. Follow
@@ -304,67 +304,37 @@ flow to inspect them after `finish()` and before `stop()`. The
 [retry](retry_progress.md) and [service](service_shutdown.md) examples log these
 snapshots.
 
-## Public names and compatibility
+## Migration from 0.9.2
 
-Use the replacement names in new code. Old names remain compatible wrappers and
-emit `DeprecationWarning` at the caller. Removal will occur only in an announced
-breaking release; no removal version is currently scheduled.
+The next breaking release removes the old method names without compatibility
+wrappers. Update calls when upgrading from 0.9.2:
 
-| Deprecated name | Replacement |
+| 0.9.2 call | Replacement |
 | --- | --- |
-| `set_all_tasks_added()` | `finish_submitting()` |
-| `wait_till_end()` | `await finish()` |
-| `start_and_wait()` | `await run()` |
-| `get_task_result()` | `await get_result()` |
-| `extract_all_results()` | `drain_results()` |
-| `apply_to_all(items)` | `await process_all(items)` |
-| `apply_to_each(items)` | `async with iter_results(items) as results` |
+| `engine.set_all_tasks_added()` | `engine.finish_submitting()` |
+| `await engine.wait_till_end()` | `await engine.finish()` |
+| `await engine.start_and_wait()` | `await engine.run()` |
+| `await engine.get_task_result()` | `await engine.get_result()` |
+| `engine.extract_all_results()` | `engine.drain_results()` |
+| `await engine.apply_to_all(items)` | `await engine.process_all(items)` |
+| `engine.apply_to_each(items)` | `async with engine.iter_results(items) as results` |
+
+For streaming, iterate `results` inside the async context shown in
+[streaming and cleanup](#streaming-and-cleanup). The context awaits cleanup on
+exit, including after an early `break`. Call `anext(results)` on the yielded
+iterator; do not call `aclose()` on the context.
 
 `start()`, `stop()`, and `add_task()` keep their names. Generic handler input and
-result types are preserved through both interfaces and the async context manager.
-For example, a handler accepting `int` makes `add_task("text")` a type error;
-this is an intentionally invalid call, not a runnable usage example.
+result types are preserved through the public methods and the async context
+manager. For example, a handler accepting `int` makes `add_task("text")` a type
+error; this is an intentionally invalid call, not a runnable usage example.
 
-### Managed streaming migration
-
-This is a pre-1.0 signature and typing break for `iter_results()`. It is now a
-regular method returning
-`AbstractAsyncContextManager[AsyncIterator[AquteTask[TData, TResult]]]`, rather
-than an async generator returning `AsyncGenerator[AquteTask[TData, TResult]]`.
-The input remains `Iterable[TData] | AsyncIterable[TData]`; the keyword-only
-`submission_batch_size: int = 1` is unchanged. Validation still occurs on first
-iteration, before input consumption. No extra import or exported type is needed
-for normal use.
-
-Before:
-
-```python
-from contextlib import aclosing
-
-async with aclosing(engine.iter_results(items)) as results:
-    async for task in results:
-        consume(task)
-```
-
-After:
-
-```python
-async with engine.iter_results(items) as results:
-    async for task in results:
-        consume(task)
-```
-
-Also replace bare `async for task in engine.iter_results(items)` with the new
-context form. Call `anext(results)` on the iterator yielded by the context.
-Do not call `aclose()` on the context returned by `iter_results()`.
-
-Deprecated `apply_to_each(items)` retains its `AsyncGenerator` return type and
-warning. Existing `async for` callers still work. Use
-`async with contextlib.aclosing(engine.apply_to_each(items)) as results` or
-explicitly await that generator's `aclose()` when stopping early. Its compatibility
-wrapper shares the same processing and cleanup path; migrate new code to the
-managed `iter_results()` form. `process_all()` keeps its coroutine signature and
-ordered list return type.
+The upgrade also requires Python 3.11 or newer and uses finite buffering by
+default for helper and manual runs. See [buffering](#buffering) for explicit unlimited settings and the
+[changelog](https://github.com/insomnes/aqute/blob/main/CHANGELOG.md) for the
+breaking changes together. The
+[0.9.x maintenance branch](https://github.com/insomnes/aqute/tree/maintenance/0.9.x)
+retains the old API for Python 3.9 and 3.10.
 
 ## For coding agents
 

--- a/tests/aqute/test_api_names.py
+++ b/tests/aqute/test_api_names.py
@@ -1,9 +1,7 @@
 import asyncio
-import contextlib
 import warnings
-from collections.abc import AsyncGenerator, AsyncIterator
+from collections.abc import AsyncIterator
 from contextlib import AbstractAsyncContextManager
-from pathlib import Path
 from typing import assert_type
 
 import pytest
@@ -50,59 +48,21 @@ async def test_canonical_methods_preserve_types_without_deprecation_warnings():
 
 
 @pytest.mark.asyncio
-async def test_legacy_lifecycle_wrappers_warn_at_the_caller_and_keep_results():
-    async with Aqute(stringify, 1, result_queue=asyncio.Queue(0)) as engine:
-        await engine.add_task(1)
-        await engine.add_task(2)
-        with pytest.warns(DeprecationWarning, match="finish_submitting") as signals:
-            engine.set_all_tasks_added()
-        with pytest.warns(DeprecationWarning, match="use finish") as finishing:
-            await engine.wait_till_end()
-        with pytest.warns(DeprecationWarning, match="use get_result") as getting:
-            result = await engine.get_task_result()
-            assert_type(result, AquteTask[int, str])
-            assert result.result == "1"
-        with pytest.warns(DeprecationWarning, match="use drain_results") as draining:
-            remaining = engine.extract_all_results()
-            assert_type(remaining, list[AquteTask[int, str]])
-            assert [item.result for item in remaining] == ["2"]
-    await engine.add_task(3)
-    try:
-        with pytest.warns(DeprecationWarning, match="use run") as running:
-            await engine.start_and_wait()
-        assert (await engine.get_result()).result == "3"
-    finally:
-        await engine.stop()
-    for caught in [signals, finishing, getting, draining, running]:
-        assert len(caught) == 1
-        assert Path(caught[0].filename) == Path(__file__)
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize("legacy", [False, True])
-async def test_helper_names_preserve_order_and_error_values(legacy):
+async def test_helper_names_preserve_order_and_error_values():
     async def handler(value: int) -> str:
         if value == 2:
             raise ValueError("failed")
         return str(value)
 
     engine = Aqute(handler, 2)
-    if legacy:
-        with pytest.warns(DeprecationWarning, match="use process_all") as caught:
-            results = await engine.apply_to_all([1, 2, 3])
-        assert len(caught) == 1
-        assert Path(caught[0].filename) == Path(__file__)
-        assert_type(results, list[AquteTask[int, str]])
-    else:
-        results = await engine.process_all([1, 2, 3])
+    results = await engine.process_all([1, 2, 3])
     assert [item.data for item in results] == [1, 2, 3]
     assert [item.result for item in results] == ["1", None, "3"]
     assert isinstance(results[1].error, ValueError)
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("legacy", [False, True])
-async def test_iterator_names_close_the_owned_work(legacy):
+async def test_iterator_names_close_the_owned_work():
     waiting = asyncio.Event()
     cleaned = asyncio.Event()
 
@@ -115,15 +75,7 @@ async def test_iterator_names_close_the_owned_work(legacy):
             cleaned.set()
 
     engine = Aqute(stringify, 1)
-    if legacy:
-        with pytest.warns(DeprecationWarning, match="use iter_results") as caught:
-            legacy_stream = engine.apply_to_each(source())
-        assert len(caught) == 1
-        assert Path(caught[0].filename) == Path(__file__)
-        assert_type(legacy_stream, AsyncGenerator[AquteTask[int, str]])
-        context = contextlib.aclosing(legacy_stream)
-    else:
-        context = engine.iter_results(source())
+    context = engine.iter_results(source())
     async with asyncio.timeout(1):
         async with context as stream:
             assert (await anext(stream)).result == "1"
@@ -133,12 +85,8 @@ async def test_iterator_names_close_the_owned_work(legacy):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "method", ["finish", "wait_till_end", "get_result", "get_task_result"]
-)
-async def test_lifecycle_aliases_preserve_not_started_errors(method):
+@pytest.mark.parametrize("method", ["finish", "get_result"])
+async def test_lifecycle_methods_preserve_not_started_errors(method):
     engine = Aqute(stringify, 1)
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", DeprecationWarning)
-        with pytest.raises(AquteError, match="Cannot"):
-            await getattr(engine, method)()
+    with pytest.raises(AquteError, match="Cannot"):
+        await getattr(engine, method)()


### PR DESCRIPTION
The next breaking release removes the seven deprecated method wrappers and keeps one public method set. Existing callers must rename methods during the upgrade and use the managed context for streaming.

The migration table and changelog collect the upgrade steps. Python 3.9/3.10 users can keep the old API on the 0.9.x maintenance branch.
