### PR TITLE
feat!: unify bounded queue defaults for all runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ improve throughput for small tasks at the cost of result latency. The default
 preserves per-item cooperative yielding. Handlers still receive one item per call;
 configure worker concurrency and queue limits separately.
 
+All APIs default each queue to `workers_count` items. Manual runs must consume
+results concurrently, or explicitly choose unlimited queues with `0` for
+[run-then-drain or pre-submission](https://insomnes.github.io/aqute/usage/#queue-default-migration).
+
 ## Bounded HTTP processing
 
 The [runnable HTTP example](https://insomnes.github.io/aqute/http_client/) combines
@@ -64,6 +68,7 @@ The [documentation](https://insomnes.github.io/aqute/) includes the complete qui
 [Usage](https://insomnes.github.io/aqute/usage/) covers bounded buffering, streaming cleanup, rate limits,
 retries, shutdown, counters, and deprecated method names. Full examples cover
 [streaming](https://insomnes.github.io/aqute/streaming/), [bounded HTTP processing](https://insomnes.github.io/aqute/http_client/),
+[manual result draining](https://insomnes.github.io/aqute/manual_drain/),
 and [service shutdown](https://insomnes.github.io/aqute/service_shutdown/).
 
 The [documentation source](https://github.com/insomnes/aqute/blob/main/docs/index.md) includes code directly from these

--- a/aqute/engine.py
+++ b/aqute/engine.py
@@ -59,8 +59,8 @@ class Aqute(Generic[TData, TResult]):
                 Defaults to None.
             result_queue (optional): Caller-owned queue for task results. Its
                 capacity also limits the internal result relay; 0 is unlimited.
-                If omitted, helpers use workers_count items per result queue;
-                manual runs use an unlimited queue.
+                If omitted, each result queue has capacity workers_count
+                for helper and manual runs alike.
             retry_count (optional): Number of task retry attempts upon
                 failure. Defaults to 0.
             retry_delay (optional): Map the 1-based failed-attempt number and
@@ -74,9 +74,9 @@ class Aqute(Generic[TData, TResult]):
             start_timeout_seconds (optional): Wait time before failing after start
                 if no tasks were added. Defaults to None.
             input_task_queue_size (optional): Maximum pending input items.
-                None (the default) uses workers_count for helper runs and no
-                limit for manual runs. Positive values set an explicit capacity;
-                0 is unlimited for both APIs.
+                None (the default) uses workers_count for all runs. Positive
+                values set an explicit capacity; 0 is unlimited. Start processing
+                before filling a bounded queue and consume results concurrently.
             use_priority_queue (optional): Use priority queue for tasks.
                 Defaults to False.
             task_timeout_seconds (optional): Timeout for task handler coroutine wait.
@@ -86,13 +86,11 @@ class Aqute(Generic[TData, TResult]):
             total_failed_tasks_limit (optional): Maximum failed tasks count before
                 stopping processing. Defaults to None.
         """
-        self._owns_result_queue = result_queue is None
         self.result_queue: AquteTaskQueueType[TData, TResult] = (
-            asyncio.Queue() if result_queue is None else result_queue
+            asyncio.Queue(workers_count) if result_queue is None else result_queue
         )
 
         self._task_tries_count = max(retry_count, 0) + 1
-        self._input_task_queue_size = input_task_queue_size
 
         self._rate_limiter = rate_limiter
 
@@ -108,7 +106,11 @@ class Aqute(Generic[TData, TResult]):
             handle_coro=self._handle_coro,
             workers_count=self._workers_count,
             rate_limiter=self._rate_limiter,
-            input_task_queue_size=max(self._input_task_queue_size or 0, 0),
+            input_task_queue_size=(
+                workers_count
+                if input_task_queue_size is None
+                else max(input_task_queue_size, 0)
+            ),
             use_priority_queue=self._use_priority_queue,
             task_timeout_seconds=self._task_timeout_seconds,
             output_task_queue_size=self.result_queue.maxsize,
@@ -225,6 +227,11 @@ class Aqute(Generic[TData, TResult]):
 
         Returns:
             The unique task_id associated with the added task.
+
+        Raises:
+            AquteError: If the input queue is full before start(). Start processing
+                or set input_task_queue_size=0 for unlimited pre-submission.
+                Also raised when the load has completed or was cancelled.
         """
         task_id = task_id or str(self._added_tasks_count)
 
@@ -240,6 +247,11 @@ class Aqute(Generic[TData, TResult]):
                 raise AquteError("Load was cancelled; call stop first")
             await load
             raise AquteError("Cannot add a task after load completion; call stop first")
+        if load is None and self._foreman.in_queue.full():
+            raise AquteError(
+                "Input queue is full before start(); call start() first "
+                "or set input_task_queue_size=0 for unlimited pre-submission"
+            )
         if load is None or not self._foreman.in_queue.full():
             await self._foreman.add_task(task)
         else:
@@ -301,7 +313,7 @@ class Aqute(Generic[TData, TResult]):
         These are item bounds, not byte bounds; source and caller retention are
         excluded. Explicit input_task_queue_size=0 or result_queue=Queue(0)
         disables the corresponding limit. Supplied result queues retain their
-        identity and capacity. Manual runs keep their original queue limits.
+        identity and capacity. Manual runs use the same queue limits.
 
         Args:
             tasks_data: Iterable containing data for each task.
@@ -376,29 +388,12 @@ class Aqute(Generic[TData, TResult]):
                 "Use a fresh engine, or complete and stop the existing run "
                 "before starting a helper"
             )
-        original_result_queue = self.result_queue
-        if not original_result_queue.empty():
+        if not self.result_queue.empty():
             raise AquteError(
                 "Drain retained results or use a fresh engine "
                 "before starting a helper run"
             )
-        if self._owns_result_queue:
-            self.result_queue = asyncio.Queue(self._workers_count)
-        self._foreman.reset(
-            input_task_queue_size=(
-                self._workers_count
-                if self._input_task_queue_size is None
-                else max(self._input_task_queue_size, 0)
-            ),
-            output_task_queue_size=self.result_queue.maxsize,
-        )
-        try:
-            yield
-        finally:
-            if self._owns_result_queue:
-                while not self.result_queue.empty():
-                    original_result_queue.put_nowait(self.result_queue.get_nowait())
-                self.result_queue = original_result_queue
+        yield
 
     async def _produce_tasks(
         self,

--- a/docs/development.md
+++ b/docs/development.md
@@ -13,14 +13,15 @@ uv run --locked python -m examples.quickstart
 uv run --locked python -m examples.streaming
 uv run --locked python -m examples.retry_progress
 uv run --locked python -m examples.http_client
+uv run --locked python -m examples.manual_drain
 uv run --locked python -m examples.service_shutdown
 ```
 
 `make check` runs Ruff formatting and lint checks, ty, pytest with coverage, and a
 strict documentation build.
 The example tests verify returned values, failures, and cleanup. Entrypoint checks
-execute `quickstart`, `streaming`, `retry_progress`, and `http_client`. Commands use
-`uv.lock`; update dependencies with `uv lock --upgrade` and verify them with
+execute `quickstart`, `streaming`, `retry_progress`, `http_client`, and `manual_drain`.
+Commands use `uv.lock`; update dependencies with `uv lock --upgrade` and verify them with
 `make check`. CI tests Python 3.11, 3.12, 3.13, and 3.14.
 
 `make wheel-smoke SMOKE_PYTHON=3.14` builds a wheel, installs it without dependencies

--- a/docs/index.md
+++ b/docs/index.md
@@ -32,7 +32,8 @@ result.
 
 See [usage](usage.md) for buffering, cleanup, retry, timeout, and compatibility
 contracts. The executable examples cover [streaming](streaming.md),
-[bounded HTTP processing](http_client.md), and [service shutdown](service_shutdown.md).
+[bounded HTTP processing](http_client.md), [manual result draining](manual_drain.md),
+and [service shutdown](service_shutdown.md).
 
 ## Bounded HTTP processing
 
@@ -65,11 +66,11 @@ For infrastructure changes, retries can repeat side effects; the application mus
 decide which operations are safe to repeat. For remote inference, Aqute schedules
 handler attempts; model execution and provider-specific policy remain outside it.
 
-`process_all()` and `iter_results()` use finite input and result buffering by
-default, with each queue sized to `workers_count`. Manual processing keeps
-unlimited defaults. Queue limits bound items, not bytes; `process_all()` retains
-the complete result list. See [buffering](usage.md#buffering) for overrides, the
-item bound, and migration.
+`process_all()`, `iter_results()`, and manual processing use finite input and result
+buffering by default, with each queue sized to `workers_count`. Manual runs must
+consume results concurrently or [choose unlimited queues explicitly](usage.md#queue-default-migration).
+Queue limits bound items, not bytes; `process_all()` retains the complete result
+list. See [buffering](usage.md#buffering) for overrides, the item bound, and migration.
 
 The `iter_results()` context awaits producer and worker cleanup, including after
 early exit. See [streaming and cleanup](usage.md#streaming-and-cleanup) for the

--- a/docs/manual_drain.md
+++ b/docs/manual_drain.md
@@ -1,0 +1,24 @@
+# Manual result draining
+
+Use the manual API to submit custom task IDs and priorities. If those features
+are unnecessary, prefer `process_all()` for an ordered result list.
+
+Start the engine before submitting, then wait for completion and drain results.
+This run-then-drain flow must use `result_queue=asyncio.Queue(0)` because no
+consumer runs during processing. The input queue keeps its default capacity of
+`workers_count`. Results accumulate in memory until drained.
+
+For bounded result buffering, consume `get_result()` concurrently instead; see
+[service shutdown](service_shutdown.md). To submit all inputs before starting,
+set `input_task_queue_size=0` as well. See [queue-default migration](usage.md#queue-default-migration).
+
+Lower priorities run first among pending tasks. They do not preempt active
+workers. The example sorts the returned values by task ID and runs offline.
+
+```bash
+uv run --locked python -m examples.manual_drain
+```
+
+```python
+--8<-- "examples/manual_drain.py"
+```

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -60,23 +60,18 @@ consuming input. Use the manual API for externally managed producers and consume
 
 ## Buffering
 
-`process_all()` and `iter_results()` use finite buffering by default. With `W`
-workers, omitted limits give each queue capacity `W`: pending input, terminal
-results, and the internal worker-result queue. Slow result consumption blocks
-further processing and admission.
+All Aqute runs use finite buffering by default, including the manual API. With
+`W` workers, omitted limits or `None` give each queue capacity `W`: pending input,
+terminal results, and the internal worker-result queue. Slow result consumption
+blocks further processing and admission.
 
-| Constructor option | Helper runs | Manual runs |
-| --- | --- | --- |
-| Omitted `input_task_queue_size`, or `None` | Capacity `W` | Unlimited |
-| `input_task_queue_size=I`, with `I > 0` | Capacity `I` | Capacity `I` |
-| `input_task_queue_size=0` | Unlimited | Unlimited |
-| Omitted `result_queue`, or `None` | Capacity `W` per result queue | Unlimited |
-| `result_queue=asyncio.Queue(R)` | Supplied queue and relay use `R` | Supplied queue and relay use `R` |
-
-A supplied result queue keeps its identity and capacity, including explicit
-`asyncio.Queue(0)` for unlimited results. Aqute does not resize or replace it.
-After helper cleanup, manual runs keep their original queue limits and already
-published results remain available through `get_result()` or `drain_results()`.
+Set `input_task_queue_size=I` to override the input capacity. A positive value is
+a finite item limit; `input_task_queue_size=0` is unlimited.
+A supplied `result_queue=asyncio.Queue(R)` sets both result queues to capacity `R`.
+It keeps its identity and capacity, including `asyncio.Queue(0)` for unlimited
+results. Aqute does not resize or replace it. Helper and manual runs use the same
+limits, including after reuse. Published results remain available after cleanup
+through `get_result()` or `drain_results()`.
 
 With positive input capacity `I`, result capacity `R`, and one producer, Aqute
 retains at most `I + 2*R + W + 3` input/result items, including pending admission,
@@ -88,10 +83,15 @@ source or caller and the growing list returned by `process_all()`. A queue size 
 zero is unlimited. Multiple independent producer calls can each hold an item
 while waiting for admission; the formula above assumes one producer.
 
-This pre-1.0 change replaces the constructor default
-`input_task_queue_size: int = 0` with `input_task_queue_size: int | None = None`.
-Existing positive capacities still override the defaults. To preserve the old
-unlimited helper behavior, set both limits explicitly:
+### Queue-default migration
+
+This is a pre-1.0 behavior break for manual runs. Omitted limits now use capacity
+`workers_count`, just like helper runs. Existing positive capacities and explicit
+zero limits keep their meaning. Manual runs using the defaults must consume
+results concurrently with submission and processing.
+
+To preserve pre-submit-then-run or other unlimited buffering, set both limits
+explicitly:
 
 ```python
 engine = Aqute(
@@ -102,8 +102,16 @@ engine = Aqute(
 )
 ```
 
-Manual pre-submit-then-run and run-then-drain flows with omitted limits need no
-migration. Deprecated helper names inherit the new helper defaults.
+Pre-submit-then-run needs both queues unlimited when all inputs are submitted
+before starting and results are drained after completion. A full input queue
+before `start()` now raises `AquteError` from `add_task()` instead of waiting
+indefinitely. Start processing first or opt into unlimited input explicitly.
+
+Run-then-drain starts processing before submission and needs only
+`result_queue=asyncio.Queue(0)`; the input queue can keep its default capacity.
+See the [manual drain example](manual_drain.md). With finite result queues and no
+concurrent consumer, `add_task()` or `finish()` can wait indefinitely. Aqute does
+not detect this arrangement. Deprecated methods use the same queue defaults.
 
 Helpers now reject pending manual tasks, so preloading with `add_task()` before
 `process_all()` or `iter_results()` raises `AquteError`. Follow
@@ -189,16 +197,21 @@ group. See [HTTPX's async client guide](https://www.python-httpx.org/async/).
 ## Manual processing and shutdown
 
 Use the Aqute async context manager, or `start()` followed by `stop()`. Start workers
-before filling a bounded input queue. Submit with `await add_task(data)` and
-consume with `await get_result()`. Custom IDs use `task_id`; omitted IDs are
-generated. `drain_results()` removes currently available results without waiting.
+before filling a bounded input queue; otherwise `add_task()` raises `AquteError`
+when the input queue is already full. With default limits, submit with
+`await add_task(data)` and consume results concurrently with `await get_result()`.
+Custom IDs use `task_id`; omitted IDs are generated. `drain_results()` removes currently available results without waiting.
 `get_result()` raises `AquteError` after normal completion when no results remain.
 
 `finish_submitting()` signals that input submission is complete. `await finish()`
 also sends that signal and waits for processing. Stop producers before either
 call. These methods do not reject later submissions while the run still has work.
 `await run()` starts processing and finishes work submitted before start.
-After `run()` or `finish()` completes, await `stop()` before starting a helper.
+With finite result queues, keep the consumer running while awaiting completion.
+For pre-submit-then-run, explicitly set both queues unlimited. For run-then-drain,
+set only the result queue unlimited; see [queue-default migration](#queue-default-migration)
+and the [manual drain example](manual_drain.md). After `run()` or `finish()`
+completes, await `stop()` before starting a helper.
 
 The executable [service shutdown example](service_shutdown.md) shows:
 
@@ -323,8 +336,8 @@ source instead of reconstructing the API from older examples.
   after completion, early exit, or failure. Keep the external client open around
   that context. Aqute closes started generator sources; callers own other source
   resources and must close them explicitly.
-- Leave queue limits omitted for finite helper defaults, with each queue sized to
-  `workers_count`. Use positive capacities to override them; zero is unlimited.
+- Leave queue limits omitted for finite defaults in all APIs, with each queue
+  sized to `workers_count`. Use positive capacities to override them; zero is unlimited.
   These are item limits. Payload bytes, caller-retained data, and the complete
   list returned by `process_all()` are outside the bound. See [buffering](#buffering).
 - Handle each terminal task explicitly. `task.unwrap()` returns the successful

--- a/examples/manual_drain.py
+++ b/examples/manual_drain.py
@@ -1,0 +1,35 @@
+"""Submit custom task IDs and priorities, then drain results after completion."""
+
+import asyncio
+import logging
+
+from aqute import Aqute
+
+
+async def handle(value: int) -> int:
+    return value * 2
+
+
+async def main() -> list[tuple[str, int]]:
+    # Use process_all() when custom task IDs and priorities are unnecessary.
+    engine = Aqute(
+        handle,
+        workers_count=2,
+        use_priority_queue=True,
+        # Results must be unlimited because consumption starts after finish().
+        result_queue=asyncio.Queue(0),
+    )
+    async with engine:
+        for value in range(10):
+            await engine.add_task(
+                value, task_id=f"job-{value}", task_priority=10 - value
+            )
+        await engine.finish()
+
+    # Priority applies to pending tasks; it does not preempt active workers.
+    return sorted((task.task_id, task.unwrap()) for task in engine.drain_results())
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    logging.info("Results: %s", asyncio.run(main()))

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -14,6 +14,7 @@ nav:
   - Streaming: streaming.md
   - Retry and progress: retry_progress.md
   - HTTP client: http_client.md
+  - Manual result draining: manual_drain.md
   - Service shutdown: service_shutdown.md
   - Development: development.md
 markdown_extensions:

--- a/tests/aqute/test_api_names.py
+++ b/tests/aqute/test_api_names.py
@@ -19,7 +19,7 @@ async def stringify(value: int) -> str:
 async def test_canonical_methods_preserve_types_without_deprecation_warnings():
     with warnings.catch_warnings():
         warnings.simplefilter("error", DeprecationWarning)
-        async with Aqute(stringify, 1) as engine:
+        async with Aqute(stringify, 1, result_queue=asyncio.Queue(0)) as engine:
             assert_type(engine, Aqute[int, str])
             await engine.add_task(1)
             await engine.add_task(2)
@@ -51,7 +51,7 @@ async def test_canonical_methods_preserve_types_without_deprecation_warnings():
 
 @pytest.mark.asyncio
 async def test_legacy_lifecycle_wrappers_warn_at_the_caller_and_keep_results():
-    async with Aqute(stringify, 1) as engine:
+    async with Aqute(stringify, 1, result_queue=asyncio.Queue(0)) as engine:
         await engine.add_task(1)
         await engine.add_task(2)
         with pytest.warns(DeprecationWarning, match="finish_submitting") as signals:

--- a/tests/aqute/test_counters.py
+++ b/tests/aqute/test_counters.py
@@ -21,7 +21,7 @@ async def test_pending_excludes_blocked_submission_and_running_includes_handler(
         await release.wait()
         return value
 
-    engine = Aqute(handler, 1, input_task_queue_size=1)
+    engine = Aqute(handler, 1, input_task_queue_size=1, result_queue=asyncio.Queue(0))
     assert engine.counters == AquteCounters(0, 0, 0, 0, 0)
     async with engine:
         await engine.add_task(1)
@@ -59,7 +59,7 @@ async def test_terminal_counts_survive_result_consumption_and_reset_on_reuse():
             raise ValueError("retry")
         return value
 
-    engine = Aqute(handler, 2, retry_count=1)
+    engine = Aqute(handler, 2, retry_count=1, result_queue=asyncio.Queue(0))
     async with engine:
         for value in range(3):
             await engine.add_task(value)

--- a/tests/aqute/test_errors.py
+++ b/tests/aqute/test_errors.py
@@ -70,6 +70,8 @@ async def test_too_many_failed_tasks_error(retry_count: int):
         handle_coro=failing_handler,
         retry_count=retry_count,
         total_failed_tasks_limit=2,
+        input_task_queue_size=0,
+        result_queue=asyncio.Queue(0),
     )
     for i in range(1, 6):
         await aqute.add_task(i)
@@ -132,6 +134,8 @@ async def test_not_enough_failed_tasks_for_error(retry_count: int):
         handle_coro=failing_handler,
         retry_count=retry_count,
         total_failed_tasks_limit=3,
+        input_task_queue_size=0,
+        result_queue=asyncio.Queue(0),
     )
     for i in range(1, 6):
         await aqute.add_task(i)

--- a/tests/aqute/test_flows.py
+++ b/tests/aqute/test_flows.py
@@ -59,7 +59,12 @@ def check_susccess_and_fails(
 
 @pytest.mark.asyncio
 async def test_most_verbose_way():
-    aqute = Aqute(workers_count=2, handle_coro=non_failing_handler)
+    aqute = Aqute(
+        workers_count=2,
+        handle_coro=non_failing_handler,
+        input_task_queue_size=0,
+        result_queue=asyncio.Queue(0),
+    )
     await add_tasks(aqute, 10)
     aqute.finish_submitting()
     await aqute.start()
@@ -70,7 +75,9 @@ async def test_most_verbose_way():
 
 @pytest.mark.asyncio
 async def test_simple_way():
-    aqute = Aqute(workers_count=2, handle_coro=non_failing_handler)
+    aqute = Aqute(
+        workers_count=2, handle_coro=non_failing_handler, result_queue=asyncio.Queue(0)
+    )
     async with aqute:
         await add_tasks(aqute, 10)
         await aqute.finish()
@@ -80,7 +87,12 @@ async def test_simple_way():
 
 @pytest.mark.asyncio
 async def test_simple_way_add_before():
-    aqute = Aqute(workers_count=2, handle_coro=non_failing_handler)
+    aqute = Aqute(
+        workers_count=2,
+        handle_coro=non_failing_handler,
+        input_task_queue_size=0,
+        result_queue=asyncio.Queue(0),
+    )
     await add_tasks(aqute, 10)
     async with aqute:
         await aqute.finish()
@@ -90,7 +102,12 @@ async def test_simple_way_add_before():
 
 @pytest.mark.asyncio
 async def test_simple_verbose():
-    aqute = Aqute(workers_count=2, handle_coro=non_failing_handler)
+    aqute = Aqute(
+        workers_count=2,
+        handle_coro=non_failing_handler,
+        input_task_queue_size=0,
+        result_queue=asyncio.Queue(0),
+    )
     await add_tasks(aqute, 10)
     await aqute.run()
     await aqute.stop()
@@ -100,7 +117,9 @@ async def test_simple_verbose():
 
 @pytest.mark.asyncio
 async def test_start_without_await():
-    aqute = Aqute(workers_count=2, handle_coro=non_failing_handler)
+    aqute = Aqute(
+        workers_count=2, handle_coro=non_failing_handler, result_queue=asyncio.Queue(0)
+    )
     aqute.start()
     await add_tasks(aqute, 10)
     await aqute.finish()
@@ -111,7 +130,9 @@ async def test_start_without_await():
 
 @pytest.mark.asyncio
 async def test_failed_tasks():
-    aqute = Aqute(workers_count=2, handle_coro=failing_handler)
+    aqute = Aqute(
+        workers_count=2, handle_coro=failing_handler, result_queue=asyncio.Queue(0)
+    )
     async with aqute:
         await add_tasks(aqute, 10)
         await aqute.finish()
@@ -125,6 +146,7 @@ async def test_total_failed_tasks_limit_do_not_intervene():
         workers_count=2,
         handle_coro=failing_handler,
         total_failed_tasks_limit=2,
+        result_queue=asyncio.Queue(0),
     )
     async with aqute:
         await add_tasks(aqute, 10)

--- a/tests/aqute/test_helper_defaults.py
+++ b/tests/aqute/test_helper_defaults.py
@@ -153,8 +153,8 @@ async def test_explicit_unlimited_result_queue_keeps_all_completed_results():
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("exit_mode", ["complete", "break", "error", "cancel"])
-async def test_helper_exit_retains_results_and_restores_manual_defaults(exit_mode):
-    """Every exit preserves retained results and later manual preload/drain."""
+async def test_helper_exit_retains_results_and_keeps_bounded_manual_defaults(exit_mode):
+    """Every exit preserves retained results and bounded defaults on manual reuse."""
     engine = Aqute(echo, 2)
     exhausted = asyncio.Event()
 
@@ -187,13 +187,16 @@ async def test_helper_exit_retains_results_and_restores_manual_defaults(exit_mod
         assert Counter([*consumed, *[task.result for task in retained]]) == Counter(
             range(3)
         )
-        for value in range(40):
-            await engine.add_task(value)
-        await engine.run()
-        assert Counter(task.result for task in engine.drain_results()) == Counter(
-            range(40)
-        )
-        await engine.stop()
+        assert engine.result_queue.maxsize == 2
+        await engine.add_task(10)
+        await engine.add_task(11)
+        with pytest.raises(AquteError, match=r"start\(\)"):
+            await engine.add_task(12)
+        assert engine.counters.pending == 2
+        async with engine:
+            manual = [await engine.get_result() for _ in range(2)]
+            await engine.finish()
+        assert Counter(task.result for task in manual) == Counter([10, 11])
 
 
 @pytest.mark.asyncio

--- a/tests/aqute/test_lifecycle.py
+++ b/tests/aqute/test_lifecycle.py
@@ -152,7 +152,9 @@ async def test_stop_resets_failure_count_and_preserves_results():
     async def handler(_value: int) -> int:
         raise ValueError("failed task")
 
-    engine = Aqute(handler, 1, total_failed_tasks_limit=2)
+    engine = Aqute(
+        handler, 1, total_failed_tasks_limit=2, result_queue=asyncio.Queue(0)
+    )
     for value in range(2):
         async with engine:
             await engine.add_task(value)

--- a/tests/aqute/test_priority_queue.py
+++ b/tests/aqute/test_priority_queue.py
@@ -16,6 +16,8 @@ async def test_priority_queue():
         workers_count=1,
         handle_coro=non_failing_handler,
         use_priority_queue=True,
+        input_task_queue_size=0,
+        result_queue=asyncio.Queue(0),
     )
     await aqute.add_task(1_000_000)
     await aqute.add_task(10, task_priority=10)

--- a/tests/aqute/test_queue_size.py
+++ b/tests/aqute/test_queue_size.py
@@ -2,12 +2,12 @@ import asyncio
 
 import pytest
 
-from aqute import Aqute
+from aqute import Aqute, AquteError
 
 
 async def run_with_queue_size(
     workers_count: int,
-    input_queue_size: int,
+    input_queue_size: int | None,
     tasks_to_add: int,
     use_priority_queue: bool = False,
 ) -> None:
@@ -24,12 +24,15 @@ async def run_with_queue_size(
         workers_count=workers_count,
         input_task_queue_size=input_queue_size,
         use_priority_queue=use_priority_queue,
+        result_queue=asyncio.Queue(0),
     )
+
+    capacity = workers_count if input_queue_size is None else input_queue_size
 
     async def submit(i: int, submitting: asyncio.Event) -> str:
         submitting.set()
         task_id = await aqute.add_task(i)
-        assert aqute.counters.pending <= input_queue_size
+        assert aqute.counters.pending <= capacity
         return task_id
 
     # This watchdog detects stalled progress; elapsed time is not an oracle.
@@ -40,18 +43,18 @@ async def run_with_queue_size(
                 await aqute.add_task(i)
                 active.append(await started.get())
 
-            if input_queue_size == 0:
+            if capacity == 0:
                 # Every remaining input is admitted while all workers are held.
                 for i in range(workers_count, tasks_to_add):
                     await aqute.add_task(i)
                 assert aqute.counters.pending == tasks_to_add - workers_count
             else:
-                capacity = workers_count + input_queue_size
-                for i in range(workers_count, capacity):
+                occupied = workers_count + capacity
+                for i in range(workers_count, occupied):
                     await aqute.add_task(i)
-                assert aqute.counters.pending == input_queue_size
+                assert aqute.counters.pending == capacity
 
-                for i in range(capacity, tasks_to_add):
+                for i in range(occupied, tasks_to_add):
                     submitting = asyncio.Event()
                     submission = submissions.create_task(submit(i, submitting))
                     await submitting.wait()
@@ -61,7 +64,7 @@ async def run_with_queue_size(
                     release[active.pop(0)].set()
                     active.append(await started.get())
                     await submission
-                    assert aqute.counters.pending == input_queue_size
+                    assert aqute.counters.pending == capacity
 
             for gate in release:
                 gate.set()
@@ -78,7 +81,7 @@ async def run_with_queue_size(
 
 
 @pytest.mark.asyncio
-async def test_no_queue_size():
+async def test_unlimited_input_queue():
     await run_with_queue_size(1, 0, 6)
 
 
@@ -106,3 +109,97 @@ async def test_two_workers_size_two():
 @pytest.mark.asyncio
 async def test_three_workers_size_two():
     await run_with_queue_size(3, 2, 12)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("workers_count", [1, 2])
+async def test_default_input_capacity(workers_count):
+    """Omitted input capacity blocks admission at workers_count pending items."""
+    await run_with_queue_size(workers_count, None, 10)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("capacity", [None, 3])
+@pytest.mark.parametrize("use_priority_queue", [False, True])
+async def test_full_input_before_start_rejects_without_admitting(
+    capacity, use_priority_queue
+):
+    """Pre-start overflow raises promptly and leaves accepted work intact."""
+
+    async def double(value: int) -> int:
+        return value * 2
+
+    engine = Aqute(
+        double, 2, input_task_queue_size=capacity, use_priority_queue=use_priority_queue
+    )
+    limit = 2 if capacity is None else capacity
+    async with asyncio.timeout(1):
+        for value in range(limit):
+            assert await engine.add_task(value) == str(value)
+        with pytest.raises(AquteError, match=r"start\(\).*input_task_queue_size"):
+            await engine.add_task(99)
+        assert engine.counters.pending == limit
+        async with engine:
+            results = [await engine.get_result() for _ in range(limit)]
+            assert await engine.add_task(limit) == str(limit)
+            results.append(await engine.get_result())
+            await engine.finish()
+    assert sorted((task.data, task.unwrap()) for task in results) == [
+        (value, value * 2) for value in range(limit + 1)
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("pre_submit", [False, True])
+async def test_manual_run_then_drain_with_explicit_unlimited_queues(pre_submit):
+    """Documented manual settings finish all work before result consumption."""
+
+    async def double(value: int) -> int:
+        return value * 2
+
+    queue = asyncio.Queue(0)
+    engine = Aqute(
+        double,
+        4,
+        input_task_queue_size=0 if pre_submit else None,
+        result_queue=queue,
+    )
+    async with asyncio.timeout(2):
+        try:
+            if not pre_submit:
+                engine.start()
+            for value in range(100):
+                await engine.add_task(value, task_id=f"job-{value}")
+            if pre_submit:
+                await engine.run()
+            else:
+                await engine.finish()
+        finally:
+            await engine.stop()
+    assert engine.result_queue is queue
+    assert sorted(
+        (task.data, task.task_id, task.unwrap()) for task in engine.drain_results()
+    ) == [(value, f"job-{value}", value * 2) for value in range(100)]
+
+
+@pytest.mark.asyncio
+async def test_default_manual_queues_with_concurrent_consumer():
+    """Default manual queues finish a large batch when results drain concurrently."""
+
+    async def double(value: int) -> int:
+        return value * 2
+
+    engine = Aqute(double, 4)
+    assert engine.result_queue.maxsize == 4
+
+    async def consume():
+        return [await engine.get_result() for _ in range(100)]
+
+    async with asyncio.timeout(2), engine, asyncio.TaskGroup() as group:
+        consumer = group.create_task(consume())
+        for value in range(100):
+            await engine.add_task(value)
+        await engine.finish()
+    assert sorted(task.unwrap() for task in consumer.result()) == [
+        value * 2 for value in range(100)
+    ]

--- a/tests/aqute/test_retries.py
+++ b/tests/aqute/test_retries.py
@@ -353,6 +353,7 @@ async def test_retry(case: RetryTestCase):
     aqute = Aqute(
         workers_count=2,
         handle_coro=get_specific_failing_handler(),
+        result_queue=asyncio.Queue(0),
         retry_count=case.retry_count,
         specific_errors_to_retry=case.specific_errors_to_retry,
         errors_to_not_retry=case.errors_to_not_retry,

--- a/tests/aqute/test_task_timeout.py
+++ b/tests/aqute/test_task_timeout.py
@@ -76,6 +76,8 @@ async def test_timeout(case: TaskTimeoutTestCase):
 
     aqute = Aqute(
         handle_coro=get_retriable_handler(),
+        input_task_queue_size=0,
+        result_queue=asyncio.Queue(0),
         workers_count=2,
         task_timeout_seconds=case.task_timeout,
         errors_to_not_retry=errors_to_not_retry,

--- a/tests/examples/test_usage.py
+++ b/tests/examples/test_usage.py
@@ -17,6 +17,7 @@ from examples import http_client, retry_progress, service_shutdown, streaming
         ("streaming", "3 consumed"),
         ("retry_progress", "[0, 2, 4, 6, 8, 10, 12, 14]"),
         ("http_client", "2 pages"),
+        ("manual_drain", str([(f"job-{value}", value * 2) for value in range(10)])),
     ],
 )
 def test_example_entrypoint(module, expected):


### PR DESCRIPTION
Manual runs and helpers now use workers_count as the default capacity for input, result, and relay queues. Explicit zero keeps a queue unlimited, and supplied result queues retain their identity and capacity.

Submitting into a full input queue before start() now raises AquteError with the available choices. The usage guide and manual-drain example show concurrent consumption, pre-submission with unlimited queues, and draining results after completion. Existing manual callers may need explicit queue settings during the upgrade.
