### PR TITLE
feat: add shared pauses to rate limiters

### DIFF
--- a/aqute/ratelimiter.py
+++ b/aqute/ratelimiter.py
@@ -3,7 +3,7 @@ import logging
 import math
 import random
 from collections import defaultdict, deque
-from time import perf_counter
+from time import monotonic, perf_counter
 from typing import Protocol
 
 from aqute.task import AquteTask
@@ -14,6 +14,59 @@ logger = logging.getLogger("aqute.ratelimiter")
 class RateLimiter(Protocol):
     async def acquire(self, name: str = "", task: AquteTask | None = None) -> None:
         """Should block inside this method if needed"""
+
+
+class PausableRateLimiter:
+    """Add a shared monotonic pause to any RateLimiter on the same event loop.
+
+    Pauses delay attempt admission, including retries, outside
+    task_timeout_seconds. A throttled attempt still consumes retry_count.
+    SDK-internal retries inside the handler multiply attempts without acquiring
+    this limiter again. Requests already admitted are not interrupted.
+
+    The inner limiter grants once per acquire(). A pause imposed during that
+    grant can delay its delivery; delayed grants may resume together.
+    """
+
+    def __init__(self, inner: RateLimiter) -> None:
+        self._inner = inner
+        self._paused_until = 0.0
+
+    @property
+    def paused_until(self) -> float:
+        """Latest monotonic deadline, initially zero; retained after expiry."""
+        return self._paused_until
+
+    def pause_for(self, seconds: float) -> None:
+        """Extend the pause by finite, nonnegative seconds from now.
+
+        A shorter pause never reduces the existing deadline. Invalid values
+        raise ValueError without changing the pause.
+        """
+        if not math.isfinite(seconds) or seconds < 0:
+            raise ValueError("seconds must be finite and nonnegative")
+        self.pause_until(monotonic() + seconds)
+
+    def pause_until(self, deadline: float) -> None:
+        """Extend the pause to a time.monotonic() deadline.
+
+        Past deadlines do not delay acquisition. A shorter deadline never
+        reduces the current pause. Nonfinite or negative values raise ValueError.
+        """
+        if not math.isfinite(deadline) or deadline < 0:
+            raise ValueError("deadline must be finite and nonnegative")
+        self._paused_until = max(self._paused_until, deadline)
+
+    async def _wait_for_pause(self) -> None:
+        # Sleep until the deadline, then check for extensions; this is not polling.
+        while (remaining := self._paused_until - monotonic()) > 0:  # noqa: ASYNC110
+            await asyncio.sleep(remaining)
+
+    async def acquire(self, name: str = "", task: AquteTask | None = None) -> None:
+        """Wait before and after the inner grant; propagate cancellation."""
+        await self._wait_for_pause()
+        await self._inner.acquire(name=name, task=task)
+        await self._wait_for_pause()
 
 
 class TokenBucketRateLimiter:

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -129,6 +129,45 @@ Available implementations are in `aqute.ratelimiter`:
 - `SlidingRateLimiter` limits calls within a moving time window.
 - `PerWorkerRateLimiter` applies a separate token bucket to each worker.
 - `RandomizedIntervalRateLimiter` adds bounded random delays after rolling-cap waits.
+- `PausableRateLimiter` wraps any limiter with a shared monotonic pause.
+
+To pause attempt admission after service throttling, share one wrapper:
+
+```python
+from aqute.ratelimiter import PausableRateLimiter, TokenBucketRateLimiter
+
+limiter = PausableRateLimiter(TokenBucketRateLimiter(max_rate=10))
+engine = Aqute(handle, workers_count=4, rate_limiter=limiter)
+# Application code can call this after a throttle response:
+limiter.pause_for(2.0)
+```
+
+`pause_for(seconds)` extends the pause from `time.monotonic()` now.
+`pause_until(deadline)` takes an absolute deadline from that same clock.
+Both accept finite, nonnegative values and raise `ValueError` otherwise.
+The later deadline wins; a shorter pause cannot shorten the current one.
+Zero seconds and past deadlines add no wait. The read-only `paused_until`
+property starts at zero and retains the latest deadline after it expires.
+
+Use the wrapper on one event loop. Each `acquire()` checks the deadline in a loop
+before and after acquiring the inner limiter, including extensions set while
+either wait is active. Cancellation propagates. Requests already admitted are
+not interrupted. Inner grants delayed by a pause can resume together; the wrapper
+does not reacquire their permits or guarantee request spacing after that delay.
+
+The pause is outside `task_timeout_seconds`. A throttled attempt still consumes
+`retry_count`; select retryable errors and allow enough retries in the application.
+SDK-internal retries inside the handler multiply requests without acquiring the
+limiter again. The [HTTP example source](http_client.md#runnable-source) parses
+`Retry-After` seconds or HTTP dates in application code and applies the shared
+pause. Missing or invalid headers use a one-second fallback; past dates use zero.
+
+Its offline entry point also compares eight workers processing forty URLs during
+one 300 ms throttle window, with `Retry-After: 1` and a 100-attempt/second limiter.
+The transport returns each response immediately, before the next admission.
+It logs throttled-request counts, retries, and elapsed time with and without the
+shared pause. Real requests already in flight can still return 429 after a pause;
+this controlled comparison is not a bound on their count or a throughput claim.
 
 `RandomizedIntervalRateLimiter(N, T)` grants at most `N` acquisitions in each
 rolling `T` seconds. Each acquisition waits for quota, then for its full additional
@@ -189,7 +228,8 @@ with `AquteTooManyTasksFailedError` when collected terminal failures reach the l
 Source exceptions propagate after helper cleanup.
 
 The [HTTP example](http_client.md) uses one shared HTTPX client and retries
-transport errors. HTTP status failures propagate to its caller. Its executable
+transport errors and HTTP 429 responses. Other HTTP status failures propagate
+to its caller. Its executable
 entry point uses an offline transport; applications call `fetch_pages(urls)` for
 real requests. HTTPX is required only for this example and is included in the dev
 group. See [HTTPX's async client guide](https://www.python-httpx.org/async/).

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -161,6 +161,8 @@ SDK-internal retries inside the handler multiply requests without acquiring the
 limiter again. The [HTTP example source](http_client.md#runnable-source) parses
 `Retry-After` seconds or HTTP dates in application code and applies the shared
 pause. Missing or invalid headers use a one-second fallback; past dates use zero.
+The example applies no upper bound to valid `Retry-After` delays. Apply any
+required delay cap in application code.
 
 Its offline entry point also compares eight workers processing forty URLs during
 one 300 ms throttle window, with `Retry-After: 1` and a 100-attempt/second limiter.

--- a/examples/http_client.py
+++ b/examples/http_client.py
@@ -2,15 +2,71 @@
 
 import asyncio
 import logging
+import math
 from collections.abc import AsyncIterable, Iterable
+from email.utils import parsedate_to_datetime
+from functools import partial
+from time import monotonic, time
 
 import httpx
 
 from aqute import Aqute
-from aqute.ratelimiter import TokenBucketRateLimiter
+from aqute.ratelimiter import PausableRateLimiter, TokenBucketRateLimiter
 from examples.retry_progress import retry_delay
 
 logger = logging.getLogger(__name__)
+TOO_MANY_REQUESTS = 429
+
+
+class RateLimitedError(httpx.HTTPStatusError):
+    """Select HTTP 429 for retries without retrying other HTTP status errors."""
+
+
+def retry_after_seconds(value: str | None) -> float:
+    """Accept nonnegative numeric seconds or an HTTP-date; default to one second.
+
+    Missing, malformed, negative, or nonfinite values use the fallback. Past
+    HTTP dates return zero. HTTP-date conversion uses wall time only here;
+    PausableRateLimiter stores the resulting delay on the monotonic clock.
+    """
+    if value is None:
+        return 1.0
+    try:
+        seconds = float(value)
+    except ValueError:
+        try:
+            deadline = parsedate_to_datetime(value)
+            if deadline.tzinfo is None:
+                return 1.0
+            return max(0.0, deadline.timestamp() - time())
+        except (TypeError, ValueError, OverflowError):
+            return 1.0
+    return seconds if math.isfinite(seconds) and seconds >= 0 else 1.0
+
+
+def http_retry_delay(failed_attempt: int, error: Exception) -> float:
+    """Keep per-worker retry delay for the comparison and transport backoff."""
+    if isinstance(error, RateLimitedError):
+        return retry_after_seconds(error.response.headers.get("Retry-After"))
+    return retry_delay(failed_attempt, error)
+
+
+async def fetch_page(
+    client: httpx.AsyncClient, url: str, limiter: PausableRateLimiter | None
+) -> str:
+    """Pause shared admission on 429; None demonstrates only per-worker delay."""
+    response = await client.get(url)
+    try:
+        response.raise_for_status()
+    except httpx.HTTPStatusError as error:
+        if response.status_code != TOO_MANY_REQUESTS:
+            raise
+        if limiter is not None:
+            limiter.pause_for(retry_after_seconds(response.headers.get("Retry-After")))
+        raise RateLimitedError(
+            str(error), request=error.request, response=error.response
+        ) from error
+    return response.text
 
 
 async def fetch_pages(
@@ -19,20 +75,19 @@ async def fetch_pages(
     transport: httpx.AsyncBaseTransport | None = None,
 ) -> int:
     """Log pages as they complete; raise the first observed terminal error."""
+    limiter = PausableRateLimiter(TokenBucketRateLimiter(max_rate=10))
     async with httpx.AsyncClient(timeout=5.0, transport=transport) as client:
 
         async def fetch(url: str) -> str:
-            response = await client.get(url)
-            response.raise_for_status()
-            return response.text
+            return await fetch_page(client, url, limiter)
 
         engine = Aqute(
             fetch,
             workers_count=4,
-            rate_limiter=TokenBucketRateLimiter(max_rate=10),
+            rate_limiter=limiter,
             retry_count=2,
-            retry_delay=retry_delay,
-            specific_errors_to_retry=httpx.TransportError,
+            retry_delay=http_retry_delay,
+            specific_errors_to_retry=(httpx.TransportError, RateLimitedError),
         )
         completed = 0
         async with engine.iter_results(urls) as results:
@@ -41,6 +96,58 @@ async def fetch_pages(
                 logger.info("Fetched %s: %s", task.data, task.unwrap())
                 completed += 1
         return completed
+
+
+async def compare_throttling() -> None:
+    """Compare eight workers against one 300 ms throttle window, offline.
+
+    The transport responds immediately, before the next paced admission. Real
+    requests already in flight can produce more 429s after a pause is set.
+    These request counts do not predict throughput for a real service.
+    """
+    workers = 8
+    urls = [f"https://example.test/jobs/{value}" for value in range(40)]
+    for shared_pause in (False, True):
+        throttled = 0
+        window_end = 0.0
+
+        def respond(request: httpx.Request) -> httpx.Response:
+            nonlocal throttled, window_end
+            if window_end == 0:
+                window_end = monotonic() + 0.3
+            if monotonic() < window_end:
+                throttled += 1
+                return httpx.Response(429, headers={"Retry-After": "1"})
+            return httpx.Response(200, text=request.url.path)
+
+        inner = TokenBucketRateLimiter(max_rate=100)
+        limiter = PausableRateLimiter(inner) if shared_pause else None
+        async with httpx.AsyncClient(transport=httpx.MockTransport(respond)) as client:
+            engine = Aqute(
+                partial(fetch_page, client, limiter=limiter),
+                workers_count=workers,
+                rate_limiter=limiter if limiter is not None else inner,
+                retry_count=2,
+                retry_delay=http_retry_delay,
+                specific_errors_to_retry=(httpx.TransportError, RateLimitedError),
+            )
+            started = monotonic()
+            completed = retries = 0
+            async with engine.iter_results(urls) as results:
+                async for task in results:
+                    task.unwrap()
+                    completed += 1
+                    retries = engine.counters.retries
+            logger.info(
+                "Throttle comparison: shared_pause=%s workers=%s pages=%s "
+                "throttled_requests=%s retries=%s elapsed=%.3fs",
+                shared_pause,
+                workers,
+                completed,
+                throttled,
+                retries,
+                monotonic() - started,
+            )
 
 
 async def main() -> int:
@@ -75,4 +182,5 @@ async def main() -> int:
 
 if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO)
+    asyncio.run(compare_throttling())
     logging.info("Results: %s pages", asyncio.run(main()))

--- a/tests/rate_limiter/test_http_pause.py
+++ b/tests/rate_limiter/test_http_pause.py
@@ -1,0 +1,73 @@
+from email.utils import formatdate
+from time import time
+
+import httpx
+import pytest
+
+from examples.http_client import fetch_pages, retry_after_seconds
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("0", 0),
+        ("2", 2),
+        ("0.5", 0.5),
+        (None, 1),
+        ("", 1),
+        ("junk", 1),
+        ("-1", 1),
+        ("nan", 1),
+        ("inf", 1),
+        ("1e309", 1),
+    ],
+)
+def test_retry_after_seconds_and_invalid_fallback(value, expected):
+    """The HTTP recipe returns usable seconds or its documented fallback."""
+    assert retry_after_seconds(value) == expected
+
+
+def test_retry_after_http_dates():
+    """HTTP dates convert from wall time; expired dates add no pause."""
+    now = time()
+    future = formatdate(now + 60, usegmt=True)
+    assert 58 < retry_after_seconds(future) <= 60
+    assert retry_after_seconds(formatdate(now - 60, usegmt=True)) == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("retry_after", ["0", formatdate(0, usegmt=True)])
+async def test_http_example_retries_429(retry_after):
+    """A 429 can recover through the public recipe's normal retry path."""
+    calls = 0
+
+    def respond(_request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return httpx.Response(429, headers={"Retry-After": retry_after})
+        return httpx.Response(200, text="recovered")
+
+    completed = await fetch_pages(
+        ["https://example.test/jobs/1"], transport=httpx.MockTransport(respond)
+    )
+    assert completed == 1
+    assert calls == 2
+
+
+@pytest.mark.asyncio
+async def test_http_example_exhausts_429_retries():
+    """A persistent 429 remains a terminal HTTP status error after three calls."""
+    calls = 0
+
+    def respond(_request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        return httpx.Response(429, headers={"Retry-After": "0"})
+
+    with pytest.raises(httpx.HTTPStatusError) as error:
+        await fetch_pages(
+            ["https://example.test/jobs/1"], transport=httpx.MockTransport(respond)
+        )
+    assert error.value.response.status_code == 429
+    assert calls == 3

--- a/tests/rate_limiter/test_pausable_rate_limiter.py
+++ b/tests/rate_limiter/test_pausable_rate_limiter.py
@@ -1,0 +1,179 @@
+import asyncio
+from time import monotonic
+
+import pytest
+
+from aqute import Aqute
+from aqute.ratelimiter import (
+    PausableRateLimiter,
+    PerWorkerRateLimiter,
+    TokenBucketRateLimiter,
+)
+from aqute.task import AquteTask
+
+
+def test_deadline_is_read_only_and_never_shortened():
+    """A later request cannot undo an existing pause through the public API."""
+    limiter = PausableRateLimiter(TokenBucketRateLimiter(1))
+    assert limiter.paused_until == 0
+    before = monotonic()
+    limiter.pause_for(1)
+    first = limiter.paused_until
+    assert before + 1 <= first <= monotonic() + 1
+    limiter.pause_for(0)
+    limiter.pause_until(first - 0.5)
+    assert limiter.paused_until == first
+    limiter.pause_until(first + 1)
+    assert limiter.paused_until == first + 1
+    with pytest.raises(AttributeError):
+        setattr(limiter, "paused_until", 0)  # noqa: B010 - exercise runtime rejection
+
+
+@pytest.mark.parametrize("value", [-1, float("inf"), -float("inf"), float("nan")])
+@pytest.mark.parametrize("method", ["pause_for", "pause_until"])
+def test_invalid_pause_leaves_existing_deadline_unchanged(method, value):
+    """Invalid caller input raises ValueError without cancelling a valid pause."""
+    limiter = PausableRateLimiter(TokenBucketRateLimiter(1))
+    limiter.pause_for(1)
+    deadline = limiter.paused_until
+    with pytest.raises(ValueError, match="finite and nonnegative"):
+        getattr(limiter, method)(value)
+    assert limiter.paused_until == deadline
+
+
+@pytest.mark.asyncio
+async def test_expired_deadline_does_not_block_and_remains_visible():
+    limiter = PausableRateLimiter(TokenBucketRateLimiter(1))
+    limiter.pause_until(monotonic() - 1)
+    deadline = limiter.paused_until
+    async with asyncio.timeout(1):
+        await limiter.acquire()
+    assert limiter.paused_until == deadline
+
+
+@pytest.mark.asyncio
+async def test_pause_blocks_all_workers_outside_handler_timeout():
+    """Every handler starts after the pause, which cannot consume its timeout."""
+    limiter = PausableRateLimiter(TokenBucketRateLimiter(8, allow_burst=True))
+    limiter.pause_for(0.06)
+    deadline = limiter.paused_until
+
+    async def handle(value: int) -> tuple[int, float]:
+        return value, monotonic()
+
+    engine = Aqute(
+        handle, workers_count=8, rate_limiter=limiter, task_timeout_seconds=0.01
+    )
+    async with asyncio.timeout(1):
+        results = await engine.process_all(range(8))
+    assert [task.unwrap()[0] for task in results] == list(range(8))
+    assert all(task.unwrap()[1] >= deadline for task in results)
+
+
+@pytest.mark.asyncio
+async def test_pause_set_during_inner_acquisition_is_honored():
+    """A grant in progress cannot admit an attempt before a newly set deadline."""
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    task = AquteTask(data="payload", task_id="request")
+    received = []
+
+    class WaitingLimiter:
+        async def acquire(self, name="", task=None):
+            received.append((name, task))
+            entered.set()
+            await release.wait()
+
+    limiter = PausableRateLimiter(WaitingLimiter())
+    async with asyncio.timeout(1):
+        async with asyncio.TaskGroup() as group:
+            acquisition = group.create_task(limiter.acquire(name="worker", task=task))
+            await entered.wait()
+            limiter.pause_for(0.06)
+            deadline = limiter.paused_until
+            release.set()
+            await acquisition
+            assert monotonic() >= deadline
+    assert received == [("worker", task)]
+
+
+@pytest.mark.asyncio
+async def test_extension_while_waiting_delays_acquisition():
+    """A sleeping acquisition must use an extension, not its original deadline."""
+    limiter = PausableRateLimiter(TokenBucketRateLimiter(1))
+    limiter.pause_for(0.04)
+    async with asyncio.timeout(1):
+        async with asyncio.TaskGroup() as group:
+            acquisition = group.create_task(limiter.acquire())
+            await asyncio.sleep(0)
+            limiter.pause_for(0.08)
+            deadline = limiter.paused_until
+            await acquisition
+            assert monotonic() >= deadline
+
+
+@pytest.mark.asyncio
+async def test_cancellation_during_pause_does_not_cancel_other_waiters():
+    """Cancelling one caller propagates and preserves the shared pause for others."""
+    limiter = PausableRateLimiter(TokenBucketRateLimiter(2, allow_burst=True))
+    limiter.pause_for(0.06)
+    deadline = limiter.paused_until
+    async with asyncio.timeout(1):
+        async with asyncio.TaskGroup() as group:
+            cancelled = group.create_task(limiter.acquire())
+            remaining = group.create_task(limiter.acquire())
+            await asyncio.sleep(0)
+            cancelled.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await cancelled
+            await remaining
+            assert monotonic() >= deadline
+    assert limiter.paused_until == deadline
+
+
+@pytest.mark.asyncio
+async def test_token_bucket_composition_preserves_rate_after_initial_pause():
+    """Normal sequential grants still obey the inner token bucket's interval."""
+    limiter = PausableRateLimiter(TokenBucketRateLimiter(1, time_period=0.05))
+    limiter.pause_for(0.03)
+    async with asyncio.timeout(1):
+        await limiter.acquire()
+        first = monotonic()
+        await limiter.acquire()
+        assert monotonic() - first >= 0.049
+
+
+@pytest.mark.asyncio
+async def test_per_worker_composition_preserves_independent_worker_limits():
+    """One worker's depleted quota must not block a different worker."""
+    limiter = PausableRateLimiter(PerWorkerRateLimiter(1, time_period=0.08))
+    limiter.pause_for(0.03)
+    async with asyncio.timeout(1):
+        await limiter.acquire("first")
+        first = monotonic()
+        async with asyncio.TaskGroup() as group:
+            waiting = group.create_task(limiter.acquire("first"))
+            await asyncio.sleep(0)
+            await limiter.acquire("second")
+            assert not waiting.done()
+            await waiting
+            assert monotonic() - first >= 0.079
+
+
+@pytest.mark.asyncio
+async def test_throttled_attempt_still_consumes_retry_budget():
+    """Repeated throttling exhausts retry_count even when each failure pauses."""
+    limiter = PausableRateLimiter(TokenBucketRateLimiter(1000))
+    attempts = 0
+
+    async def handle(_value: int) -> None:
+        nonlocal attempts
+        attempts += 1
+        limiter.pause_for(0.01)
+        raise ValueError("throttled")
+
+    engine = Aqute(handle, workers_count=1, rate_limiter=limiter, retry_count=1)
+    results = await engine.process_all([1])
+    with pytest.raises(ValueError, match="throttled"):
+        results[0].unwrap()
+    assert attempts == 2


### PR DESCRIPTION
Add PausableRateLimiter to compose a shared monotonic pause with an existing limiter. Applications can extend the pause with pause_for() or pause_until(); attempts wait outside the handler timeout, and throttled attempts still consume the retry budget. Admitted requests continue, and delayed inner grants can resume together.

The HTTP example handles 429 Retry-After values as seconds or HTTP dates. Its controlled offline example uses eight workers and 40 URLs: it observes eight throttled requests without the shared pause and one with it. The transport responds immediately; these counts are not a bound for requests already in flight.
