### PR TITLE
docs: align development installation and HTTP recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,11 @@ for a short comparison with plain asyncio and aiometer.
 
 ## Quickstart
 
-```bash
-pip install aqute
-```
+This README and the linked documentation cover the unreleased development API
+for Python 3.11+. Follow the
+[development installation instructions](https://insomnes.github.io/aqute/#development-installation)
+before running these examples. For `pip install aqute`, use the versioned
+[0.9.3 quickstart](https://github.com/insomnes/aqute/blob/0.9.3/README.md#quickstart).
 
 Pass your async handler to `Aqute`. Inside an async function, collect its results:
 
@@ -57,8 +59,9 @@ From a development checkout, run it without network access:
 uv run --locked python -m examples.http_client
 ```
 
-The example completes a transport retry, then handles a terminal HTTP error in a
-separate run. Its [source](https://github.com/insomnes/aqute/blob/main/examples/http_client.py)
+The example first compares throttling with and without a shared pause. It then
+completes a transport retry and handles a terminal HTTP error in a separate run.
+Its [source](https://github.com/insomnes/aqute/blob/main/examples/http_client.py)
 also provides an explicit path for real requests. The HTTP page includes the
 source and explains buffering overrides, retry safety, and its fail-fast policy.
 

--- a/docs/http_client.md
+++ b/docs/http_client.md
@@ -4,20 +4,34 @@ Process independent GET requests with one shared HTTPX client and a fresh Aqute
 engine per run. The example combines four workers, an attempt-rate limiter,
 selected retries, and incremental result consumption.
 
+This recipe uses the development API for Python 3.11+. Follow the
+[development installation instructions](index.md#development-installation).
+For PyPI 0.9.3, use its versioned
+[README](https://github.com/insomnes/aqute/blob/0.9.3/README.md#quickstart).
+
 From a development checkout, run the example offline:
 
 ```bash
 uv run --locked python -m examples.http_client
 ```
 
-The HTTP transport is the only fake. The first run fetches two pages after one
-temporary connection failure. A separate run returns HTTP 503, which the example
-reports as a terminal error. The entry point logs both page bodies and ends with
-`Results: 2 pages`. The two runs use separate clients and engines.
+The HTTP transport is the only fake. The entry point first compares eight workers
+processing forty URLs with and without a shared pause during a 300 ms throttle
+window. Both variants use `Retry-After: 1` and a 100-attempt/second inner limiter.
+The transport responds immediately, before the next admission. It logs throttled
+request counts, retries, and elapsed time. Requests already in flight can still
+return 429 after a pause; this controlled comparison does not bound their count
+or predict real-service throughput.
 
-For real requests, call `await fetch_pages(urls)` without a transport. Install
-`aqute` and `httpx` in your application environment. HTTPX is a development
-dependency in this checkout; it is not an Aqute runtime dependency.
+Next, it fetches two pages after one temporary connection failure. A separate run
+returns HTTP 503, which the example reports as a terminal error. The entry point
+logs both page bodies and ends with `Results: 2 pages`. Each run uses a separate
+client and engine.
+
+For real requests, call `await fetch_pages(urls)` without a transport. Install the
+[development source](index.md#development-installation) and `httpx` in your
+application environment. HTTPX is a development dependency in this checkout;
+it is not an Aqute runtime dependency.
 
 The source imports `retry_delay` from the checkout's `examples.retry_progress`,
 which is not installed with `aqute`. To adapt it outside the checkout, copy the
@@ -34,16 +48,27 @@ you define the callback in the same file.
 
 ## Limits and outcomes
 
-`workers_count=4` limits occupied workers. `TokenBucketRateLimiter(max_rate=10)`
-spaces attempt admissions by at least 0.1 seconds, including retries. It permits
-one initial attempt immediately and does not permit bursts. Each client request
-uses HTTPX's five-second timeout setting.
+In `fetch_pages()`, `workers_count=4` limits occupied workers. The inner
+`TokenBucketRateLimiter(max_rate=10)` spaces its grants by at least 0.1 seconds,
+including retries, with one initial grant available immediately.
+`PausableRateLimiter` adds a shared pause before and after the inner grant.
+Grants delayed by a pause can resume together; the wrapper does not reacquire
+permits or guarantee request spacing after that delay. Each client request uses
+HTTPX's five-second timeout setting.
 
-`retry_count=2` permits at most three attempts per URL. Only
-`httpx.TransportError` exceptions are selected for retries. HTTP status errors,
-including 429 and 503, are terminal in this example. The existing
-[retry callback](retry_progress.md) adds capped exponential backoff with jitter.
-Applications must select retryable errors and operations for their own service.
+`retry_count=2` permits at most three attempts per URL. The recipe selects
+`httpx.TransportError` and HTTP 429, represented by `RateLimitedError`, for retries.
+Other HTTP status errors, including 503, are terminal. Transport errors use the
+[retry callback](retry_progress.md) for capped exponential backoff with jitter.
+
+On HTTP 429, `fetch_pages()` applies a shared pause from `Retry-After`. The retry
+callback also uses that header for the failed worker's retry delay. The parser
+accepts nonnegative numeric seconds or HTTP dates. Missing, malformed, negative,
+or nonfinite values use one second; past dates use zero. Valid delays have no
+upper bound. Apply any required cap in application code. See the
+[pause limits](usage.md#concurrency-rate-and-priority) for admission and timeout
+behavior. Applications must select retryable errors and operations for their
+own service.
 
 Aqute yields handler failures as terminal task error values. This example calls
 `task.unwrap()` to raise the first observed error and stop the run. Already logged

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,10 +12,24 @@ Typical uses are API ingestion and backfills, infrastructure automation, and
 independent remote inference or evaluation requests. Your application owns retry
 safety, checkpoints, token budgets, and provider policy.
 
+## Development installation
+
+These pages and examples cover the unreleased development API on `main`.
+With Python 3.11+ and Git installed, install the development source:
+
+```bash
+python -m pip install "aqute @ git+https://github.com/insomnes/aqute.git@main"
+```
+
+For `pip install aqute`, follow the versioned
+[0.9.3 quickstart](https://github.com/insomnes/aqute/blob/0.9.3/README.md#quickstart).
+That PyPI release uses an older API.
+
 ## Quickstart
 
-Install the library with `pip install aqute`. This complete example returns an
-ordered list of doubled values and propagates handler errors.
+After [installing the development source](#development-installation), run this
+complete example. It returns an ordered list of doubled values and propagates
+handler errors.
 
 ```python
 --8<-- "examples/quickstart.py"
@@ -45,10 +59,11 @@ The page includes the runnable source and explains its fail-fast error policy.
 uv run --locked python -m examples.http_client
 ```
 
-This checkout command runs offline. It completes a transport retry, logs two
-pages, and handles a terminal HTTP error in a separate run. Each run uses a fresh
-engine and a managed stream with finite queue defaults. It returns a count instead
-of retaining every body. Queues bound items, not payload bytes or application data.
+This checkout command runs offline. It first compares throttling with and without
+a shared pause. It then completes a transport retry, logs two pages, and handles a
+terminal HTTP error in a separate run. Each run uses a fresh engine and a managed
+stream with finite queue defaults. `fetch_pages()` returns a count instead of
+retaining every body. Queues bound items, not payload bytes or application data.
 The same source provides an explicit callable path for real requests.
 
 See [For coding agents](usage.md#for-coding-agents) for helper selection and

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,5 +1,10 @@
 # Usage
 
+This page covers the development API for Python 3.11+. Follow the
+[development installation instructions](index.md#development-installation).
+For PyPI 0.9.3, use its versioned
+[README](https://github.com/insomnes/aqute/blob/0.9.3/README.md#quickstart).
+
 ## Task results
 
 Call `AquteTask.unwrap()` on terminal results obtained from `Aqute` through
@@ -363,10 +368,11 @@ ordered list return type.
 
 ## For coding agents
 
-For application code, install with `pip install aqute` and import
-`Aqute` from `aqute`. The [canonical HTTP recipe](http_client.md)
-also requires `httpx`; the checkout's dev group includes it. Adapt that runnable
-source instead of reconstructing the API from older examples.
+For application code, [install the development source](index.md#development-installation)
+with Python 3.11+ and import `Aqute` from `aqute`. The
+[canonical HTTP recipe](http_client.md) also requires `httpx`; the checkout's dev
+group includes it. Adapt that runnable source instead of reconstructing the API
+from older examples.
 
 | Application need | API |
 | --- | --- |


### PR DESCRIPTION
The current examples require the development API, but the installation guidance directs readers to PyPI 0.9.3. Add a Python 3.11+ source-install path and link the versioned 0.9.3 quickstart for published-package users.

Update the HTTP recipe to describe 429 retries, shared Retry-After pauses, delayed grants that can resume together, and the offline comparison that runs before the existing demonstrations. Valid Retry-After delays remain uncapped; runtime behavior is unchanged.
