### PR TITLE
docs: prepare 0.10.0 release guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.10.0 - 2026-09-08
 
 ### Breaking changes from 0.9.2
 

--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@ for a short comparison with plain asyncio and aiometer.
 
 ## Quickstart
 
-This README and the linked documentation cover the unreleased development API
+This README and the linked documentation cover the 0.10.0 API
 for Python 3.11+. Follow the
-[development installation instructions](https://insomnes.github.io/aqute/#development-installation)
-before running these examples. For `pip install aqute`, use the versioned
+[installation instructions](https://insomnes.github.io/aqute/#installation)
+before running these examples. For the 0.9.x maintenance API, use the
 [0.9.3 quickstart](https://github.com/insomnes/aqute/blob/0.9.3/README.md#quickstart).
 
 Pass your async handler to `Aqute`. Inside an async function, collect its results:

--- a/docs/http_client.md
+++ b/docs/http_client.md
@@ -4,10 +4,10 @@ Process independent GET requests with one shared HTTPX client and a fresh Aqute
 engine per run. The example combines four workers, an attempt-rate limiter,
 selected retries, and incremental result consumption.
 
-This recipe uses the development API for Python 3.11+. Follow the
-[development installation instructions](index.md#development-installation).
-For PyPI 0.9.3, use its versioned
-[README](https://github.com/insomnes/aqute/blob/0.9.3/README.md#quickstart).
+This recipe uses the 0.10.0 API for Python 3.11+. Follow the
+[installation instructions](index.md#installation).
+For the 0.9.x maintenance API, use the
+[0.9.3 quickstart](https://github.com/insomnes/aqute/blob/0.9.3/README.md#quickstart).
 
 From a development checkout, run the example offline:
 
@@ -28,8 +28,8 @@ returns HTTP 503, which the example reports as a terminal error. The entry point
 logs both page bodies and ends with `Results: 2 pages`. Each run uses a separate
 client and engine.
 
-For real requests, call `await fetch_pages(urls)` without a transport. Install the
-[development source](index.md#development-installation) and `httpx` in your
+For real requests, call `await fetch_pages(urls)` without a transport. Install
+[Aqute](index.md#installation) and `httpx` in your
 application environment. HTTPX is a development dependency in this checkout;
 it is not an Aqute runtime dependency.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,22 +12,20 @@ Typical uses are API ingestion and backfills, infrastructure automation, and
 independent remote inference or evaluation requests. Your application owns retry
 safety, checkpoints, token budgets, and provider policy.
 
-## Development installation
+## Installation
 
-These pages and examples cover the unreleased development API on `main`.
-With Python 3.11+ and Git installed, install the development source:
+These pages and examples cover the 0.10.0 API. With Python 3.11+, install Aqute:
 
 ```bash
-python -m pip install "aqute @ git+https://github.com/insomnes/aqute.git@main"
+python -m pip install aqute==0.10.0
 ```
 
-For `pip install aqute`, follow the versioned
+For the 0.9.x maintenance API, use the
 [0.9.3 quickstart](https://github.com/insomnes/aqute/blob/0.9.3/README.md#quickstart).
-That PyPI release uses an older API.
 
 ## Quickstart
 
-After [installing the development source](#development-installation), run this
+After [installing Aqute](#installation), run this
 complete example. It returns an ordered list of doubled values and propagates
 handler errors.
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,9 +1,9 @@
 # Usage
 
-This page covers the development API for Python 3.11+. Follow the
-[development installation instructions](index.md#development-installation).
-For PyPI 0.9.3, use its versioned
-[README](https://github.com/insomnes/aqute/blob/0.9.3/README.md#quickstart).
+This page covers the 0.10.0 API for Python 3.11+. Follow the
+[installation instructions](index.md#installation).
+For the 0.9.x maintenance API, use the
+[0.9.3 quickstart](https://github.com/insomnes/aqute/blob/0.9.3/README.md#quickstart).
 
 ## Task results
 
@@ -338,7 +338,7 @@ retains the old API for Python 3.9 and 3.10.
 
 ## For coding agents
 
-For application code, [install the development source](index.md#development-installation)
+For application code, [install Aqute](index.md#installation)
 with Python 3.11+ and import `Aqute` from `aqute`. The
 [canonical HTTP recipe](http_client.md) also requires `httpx`; the checkout's dev
 group includes it. Adapt that runnable source instead of reconstructing the API


### PR DESCRIPTION
Point the current API documentation to the 0.10.0 package installation and reserve the 0.9.3 link for maintenance users. Date the 0.10.0 changelog entry and update installation anchors.
