### PR TITLE
docs: expand runnable quickstart examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,36 +14,231 @@ checkpoints, token budgets, and provider policy. See
 [when to choose Aqute](https://insomnes.github.io/aqute/#when-to-choose-aqute)
 for a short comparison with plain asyncio and aiometer.
 
-## Quickstart
+## Installation
 
-This README and the linked documentation cover the 0.10.0 API
-for Python 3.11+. Follow the
-[installation instructions](https://insomnes.github.io/aqute/#installation)
-before running these examples. For the 0.9.x maintenance API, use the
-[0.9.3 quickstart](https://github.com/insomnes/aqute/blob/0.9.3/README.md#quickstart).
+Aqute requires Python 3.11+. Install the version used by these examples:
 
-Pass your async handler to `Aqute`. Inside an async function, collect its results:
-
-```python
-results = await Aqute(handle, workers_count=4).process_all(range(10))
+```bash
+python -m pip install aqute==0.10.0
 ```
 
-See the complete runnable [quickstart](https://github.com/insomnes/aqute/blob/main/examples/quickstart.py) for imports, a
-handler, error handling, and `asyncio.run()`. `process_all()` returns an awaited
-list in input order. For completion-order streaming, use
-`async with engine.iter_results(items) as results` and iterate `results` inside the
-context. Context exit awaits producer and worker cleanup, including after early
-exit. Both helpers accept synchronous and asynchronous input. Inspect each task's
-`error` or `success`; `None` can be a valid result.
+## Quickstart
+
+Save any example below as `quickstart.py` and run `python quickstart.py`.
+The first three need only Aqute and the standard library. The HTTP example also
+needs `httpx`.
+
+The first three handlers use `await asyncio.sleep(0.1)` to simulate I/O
+without blocking the event loop. The HTTP handler awaits real network I/O.
+
+### 1. Collect a finite batch in input order
+
+Start here when the full result list fits in memory. The handler receives
+one input item per call; `workers_count=4` permits up to four concurrent handlers.
+
+```python
+"""Run a finite batch and receive results in input order."""
+
+import asyncio
+import logging
+
+from aqute import Aqute
+
+
+async def handle(value: int) -> int:
+    await asyncio.sleep(0.1)  # Simulate asynchronous I/O.
+    return value * 2
+
+
+async def main() -> list[int]:
+    tasks = await Aqute(handle, workers_count=4).process_all(range(10))
+    values = [task.unwrap() for task in tasks]
+    assert values == [value * 2 for value in range(10)]
+    return values
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    logging.info("Results: %s", asyncio.run(main()))
+```
+
+The result is `[0, 2, 4, 6, 8, 10, 12, 14, 16, 18]`. `process_all()` returns
+completed task objects in input order. `task.unwrap()` returns the handler value
+or raises its error. Here, unwrapping happens after the whole batch finishes;
+it does not stop the batch on its first failure.
+
+### 2. Record errors and continue
+
+Inspect `task.error` when one bad item must not prevent you from using the
+other results. This example uses local conversion to make a failure reproducible.
+
+```python
+"""Report each failed item and keep the successful results."""
+
+import asyncio
+import logging
+
+from aqute import Aqute
+
+
+async def parse_port(value: str) -> int:
+    await asyncio.sleep(0.1)  # Simulate asynchronous I/O.
+    return int(value)
+
+
+async def main() -> None:
+    tasks = await Aqute(parse_port, workers_count=2).process_all(
+        ["443", "invalid", "8080"]
+    )
+    for task in tasks:
+        if task.error is not None:
+            logging.warning("Failed %r: %s", task.data, task.error)
+        else:
+            logging.info("Port: %s", task.unwrap())
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    asyncio.run(main())
+```
+
+This logs ports `443` and `8080`, plus a failure for `"invalid"`. Handler
+failures are stored on completed tasks; retries are disabled by default.
+Check `error` or `success`, not whether `result` is `None`: a successful handler
+can return `None`. Input-source and engine errors can still raise from a helper.
+
+### 3. Consume a stream and stop early
+
+Use `iter_results()` to consume results as they complete without collecting
+the full output. This example takes an asynchronous input source and stops
+after three results.
+
+```python
+"""Consume bounded streaming results and stop early with managed cleanup."""
+
+import asyncio
+import logging
+
+from aqute import Aqute
+
+logger = logging.getLogger(__name__)
+RESULT_LIMIT = 3
+
+
+async def main() -> int:
+    async def source():
+        try:
+            for value in range(100):
+                yield value
+        finally:
+            logger.info("Source closed")
+
+    async def handle(value: int) -> int:
+        await asyncio.sleep(0.1)  # Simulate asynchronous I/O.
+        return value * 2
+
+    engine = Aqute(handle, workers_count=3)
+    completed = 0
+    async with engine.iter_results(source()) as results:
+        async for task in results:
+            # Replace this log with application-owned processing or persistence.
+            logger.info("Result for %s: %s", task.data, task.unwrap())
+            completed += 1
+            if completed == RESULT_LIMIT:
+                break
+    # Context exit has awaited producer and worker cleanup.
+    return completed
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    logging.info("Results: %s consumed", asyncio.run(main()))
+```
+
+Results arrive in completion order, which can differ from input order.
+Leaving `async with` awaits producer and worker cleanup, including after `break`
+or an exception. Sources and handlers must cooperate with cancellation.
+Some additional items may already have started or finished before the break;
+stopping does not undo their side effects.
+
+Both helpers accept synchronous and asynchronous inputs. Each queue defaults to
+`workers_count` items. Queue limits bound item counts, not payload bytes or
+results retained by your code. `process_all()` still retains the full result list.
+
+### 4. Fetch URLs with rate limits and retries
+
+Install the optional HTTP client, then run this standalone example. It makes
+real GET requests; replace `urls` with your endpoints.
+
+```bash
+python -m pip install aqute==0.10.0 httpx
+```
+
+Keep one client open around the managed result stream so workers finish cleanup
+before their connections close.
+
+```python
+"""Fetch URLs with shared connections, rate limits, and transport retries."""
+
+import asyncio
+import logging
+
+import httpx
+
+from aqute import Aqute
+from aqute.ratelimiter import TokenBucketRateLimiter
+
+
+async def main() -> None:
+    urls = ["https://example.com/", "https://example.org/"]
+    async with httpx.AsyncClient(timeout=5.0) as client:
+
+        async def fetch(url: str) -> int:
+            response = await client.get(url)
+            response.raise_for_status()
+            return response.status_code
+
+        engine = Aqute(
+            fetch,
+            workers_count=4,
+            rate_limiter=TokenBucketRateLimiter(max_rate=5),
+            retry_count=2,
+            retry_delay=lambda _attempt, _error: 0.5,
+            specific_errors_to_retry=httpx.TransportError,
+        )
+        async with engine.iter_results(urls) as results:
+            async for task in results:
+                if task.error is not None:
+                    logging.warning("Failed %s: %s", task.data, task.error)
+                else:
+                    logging.info("%s: HTTP %s", task.data, task.unwrap())
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    asyncio.run(main())
+```
+
+`workers_count=4` limits concurrent handlers. The limiter spaces attempt
+starts by at least 0.2 seconds, including retries. `retry_count=2` allows at most
+three attempts per URL, with a fixed 0.5-second delay before each retry.
+HTTPX applies its five-second timeout to network operations, not to the entire
+batch or retry sequence.
+
+Only `httpx.TransportError` failures are retried. HTTP status errors, including
+429 and 503, are logged as terminal failures and processing continues. Choose
+retryable errors and operations for your service; retries can repeat side effects.
+HTTPX reads each response body into memory even though this example returns only
+the status code.
+
+For HTTP 429 and `Retry-After` handling, see the [shared-pause HTTP recipe](https://insomnes.github.io/aqute/http_client/).
+See [usage](https://insomnes.github.io/aqute/usage/) for retry filters, timeout contracts, queue overrides,
+and manual processing. Manual runs must consume results concurrently with the
+default finite queues.
 
 Both helpers accept `submission_batch_size` (default `1`). Larger batches can
-improve throughput for small tasks at the cost of result latency. The default
-preserves per-item cooperative yielding. Handlers still receive one item per call;
-configure worker concurrency and queue limits separately.
-
-All APIs default each queue to `workers_count` items. Manual runs must consume
-results concurrently, or explicitly choose unlimited queues with `0` for
-[run-then-drain or pre-submission](https://insomnes.github.io/aqute/usage/#queue-default-migration).
+improve throughput for small tasks at the cost of result latency. Handlers still
+receive one item per call; configure worker concurrency and queue limits separately.
 
 ## Bounded HTTP processing
 

--- a/README.md
+++ b/README.md
@@ -28,8 +28,9 @@ Save any example below as `quickstart.py` and run `python quickstart.py`.
 The first three need only Aqute and the standard library. The HTTP example also
 needs `httpx`.
 
-The first three handlers use `await asyncio.sleep(0.1)` to simulate I/O
-without blocking the event loop. The HTTP handler awaits real network I/O.
+The first three handlers use `await asyncio.sleep(uniform(0.025, 0.1))` to
+simulate I/O with a random delay of 25–100 ms without blocking the event loop.
+The HTTP handler awaits real network I/O.
 
 ### 1. Collect a finite batch in input order
 
@@ -41,12 +42,13 @@ one input item per call; `workers_count=4` permits up to four concurrent handler
 
 import asyncio
 import logging
+from random import uniform
 
 from aqute import Aqute
 
 
 async def handle(value: int) -> int:
-    await asyncio.sleep(0.1)  # Simulate asynchronous I/O.
+    await asyncio.sleep(uniform(0.025, 0.1))  # Simulate asynchronous I/O.
     return value * 2
 
 
@@ -77,12 +79,13 @@ other results. This example uses local conversion to make a failure reproducible
 
 import asyncio
 import logging
+from random import uniform
 
 from aqute import Aqute
 
 
 async def parse_port(value: str) -> int:
-    await asyncio.sleep(0.1)  # Simulate asynchronous I/O.
+    await asyncio.sleep(uniform(0.025, 0.1))  # Simulate asynchronous I/O.
     return int(value)
 
 
@@ -118,6 +121,7 @@ after three results.
 
 import asyncio
 import logging
+from random import uniform
 
 from aqute import Aqute
 
@@ -134,7 +138,7 @@ async def main() -> int:
             logger.info("Source closed")
 
     async def handle(value: int) -> int:
-        await asyncio.sleep(0.1)  # Simulate asynchronous I/O.
+        await asyncio.sleep(uniform(0.025, 0.1))  # Simulate asynchronous I/O.
         return value * 2
 
     engine = Aqute(handle, workers_count=3)

--- a/docs/http_client.md
+++ b/docs/http_client.md
@@ -6,8 +6,6 @@ selected retries, and incremental result consumption.
 
 This recipe uses the 0.10.0 API for Python 3.11+. Follow the
 [installation instructions](index.md#installation).
-For the 0.9.x maintenance API, use the
-[0.9.3 quickstart](https://github.com/insomnes/aqute/blob/0.9.3/README.md#quickstart).
 
 From a development checkout, run the example offline:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,32 +20,110 @@ These pages and examples cover the 0.10.0 API. With Python 3.11+, install Aqute:
 python -m pip install aqute==0.10.0
 ```
 
-For the 0.9.x maintenance API, use the
-[0.9.3 quickstart](https://github.com/insomnes/aqute/blob/0.9.3/README.md#quickstart).
-
 ## Quickstart
 
-After [installing Aqute](#installation), run this
-complete example. It returns an ordered list of doubled values and propagates
-handler errors.
+After [installing Aqute](#installation), save any example below as `quickstart.py`
+and run `python quickstart.py`. The first three need only Aqute and the standard
+library. The HTTP example also needs `httpx`.
+
+The first three handlers use `await asyncio.sleep(0.1)` to simulate I/O
+without blocking the event loop. The HTTP handler awaits real network I/O.
+
+### 1. Collect a finite batch in input order
+
+Start here when the full result list fits in memory. The handler receives
+one input item per call; `workers_count=4` permits up to four concurrent handlers.
 
 ```python
 --8<-- "examples/quickstart.py"
 ```
 
-From a development checkout, run `uv run --locked python -m examples.quickstart`.
+The result is `[0, 2, 4, 6, 8, 10, 12, 14, 16, 18]`. `process_all()` returns
+completed task objects in input order. `task.unwrap()` returns the handler value
+or raises its error. Here, unwrapping happens after the whole batch finishes;
+it does not stop the batch on its first failure.
 
-`await engine.process_all(items)` returns a list in input order. For
-completion-order streaming, use `async with engine.iter_results(items) as results`
-and iterate `results` inside the context. Both helpers accept `Iterable` and
-`AsyncIterable` inputs. Each terminal `AquteTask` exposes `data`, `task_id`, `result`,
-`error`, and `success`. Inspect `error` or `success`: `None` can be a valid handler
-result.
+### 2. Record errors and continue
 
-See [usage](usage.md) for buffering, cleanup, retry, timeout, and compatibility
-contracts. The executable examples cover [streaming](streaming.md),
-[bounded HTTP processing](http_client.md), [manual result draining](manual_drain.md),
-and [service shutdown](service_shutdown.md).
+Inspect `task.error` when one bad item must not prevent you from using the
+other results. This example uses local conversion to make a failure reproducible.
+
+```python
+--8<-- "examples/quickstart_errors.py"
+```
+
+This logs ports `443` and `8080`, plus a failure for `"invalid"`. Handler
+failures are stored on completed tasks; retries are disabled by default.
+Check `error` or `success`, not whether `result` is `None`: a successful handler
+can return `None`. Input-source and engine errors can still raise from a helper.
+
+### 3. Consume a stream and stop early
+
+Use `iter_results()` to consume results as they complete without collecting
+the full output. This example takes an asynchronous input source and stops
+after three results.
+
+```python
+--8<-- "examples/streaming.py"
+```
+
+Results arrive in completion order, which can differ from input order.
+Leaving `async with` awaits producer and worker cleanup, including after `break`
+or an exception. Sources and handlers must cooperate with cancellation.
+Some additional items may already have started or finished before the break;
+stopping does not undo their side effects.
+
+Both helpers accept synchronous and asynchronous inputs. Each queue defaults to
+`workers_count` items. Queue limits bound item counts, not payload bytes or
+results retained by your code. `process_all()` still retains the full result list.
+
+### 4. Fetch URLs with rate limits and retries
+
+Install the optional HTTP client, then run this standalone example. It makes
+real GET requests; replace `urls` with your endpoints.
+
+```bash
+python -m pip install aqute==0.10.0 httpx
+```
+
+Keep one client open around the managed result stream so workers finish cleanup
+before their connections close.
+
+```python
+--8<-- "examples/quickstart_http.py"
+```
+
+`workers_count=4` limits concurrent handlers. The limiter spaces attempt
+starts by at least 0.2 seconds, including retries. `retry_count=2` allows at most
+three attempts per URL, with a fixed 0.5-second delay before each retry.
+HTTPX applies its five-second timeout to network operations, not to the entire
+batch or retry sequence.
+
+Only `httpx.TransportError` failures are retried. HTTP status errors, including
+429 and 503, are logged as terminal failures and processing continues. Choose
+retryable errors and operations for your service; retries can repeat side effects.
+HTTPX reads each response body into memory even though this example returns only
+the status code.
+
+For HTTP 429 and `Retry-After` handling, see the [shared-pause HTTP recipe](http_client.md).
+See [usage](usage.md) for retry filters, timeout contracts, queue overrides,
+and manual processing. Manual runs must consume results concurrently with the
+default finite queues.
+
+Both helpers accept `submission_batch_size` (default `1`). Larger batches can
+improve throughput for small tasks at the cost of result latency. Handlers still
+receive one item per call; configure worker concurrency and queue limits separately.
+
+From a development checkout, run the dependency-free examples directly:
+
+```bash
+uv run --locked python -m examples.quickstart
+uv run --locked python -m examples.quickstart_errors
+uv run --locked python -m examples.streaming
+```
+
+`uv run --locked python -m examples.quickstart_http` makes real network requests.
+The HTTP recipe below provides a separate offline example.
 
 ## Bounded HTTP processing
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,8 +26,9 @@ After [installing Aqute](#installation), save any example below as `quickstart.p
 and run `python quickstart.py`. The first three need only Aqute and the standard
 library. The HTTP example also needs `httpx`.
 
-The first three handlers use `await asyncio.sleep(0.1)` to simulate I/O
-without blocking the event loop. The HTTP handler awaits real network I/O.
+The first three handlers use `await asyncio.sleep(uniform(0.025, 0.1))` to
+simulate I/O with a random delay of 25–100 ms without blocking the event loop.
+The HTTP handler awaits real network I/O.
 
 ### 1. Collect a finite batch in input order
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -2,8 +2,6 @@
 
 This page covers the 0.10.0 API for Python 3.11+. Follow the
 [installation instructions](index.md#installation).
-For the 0.9.x maintenance API, use the
-[0.9.3 quickstart](https://github.com/insomnes/aqute/blob/0.9.3/README.md#quickstart).
 
 ## Task results
 

--- a/examples/quickstart.py
+++ b/examples/quickstart.py
@@ -2,12 +2,13 @@
 
 import asyncio
 import logging
+from random import uniform
 
 from aqute import Aqute
 
 
 async def handle(value: int) -> int:
-    await asyncio.sleep(0.1)  # Simulate asynchronous I/O.
+    await asyncio.sleep(uniform(0.025, 0.1))  # Simulate asynchronous I/O.
     return value * 2
 
 

--- a/examples/quickstart.py
+++ b/examples/quickstart.py
@@ -7,6 +7,7 @@ from aqute import Aqute
 
 
 async def handle(value: int) -> int:
+    await asyncio.sleep(0.1)  # Simulate asynchronous I/O.
     return value * 2
 
 

--- a/examples/quickstart_errors.py
+++ b/examples/quickstart_errors.py
@@ -1,0 +1,27 @@
+"""Report each failed item and keep the successful results."""
+
+import asyncio
+import logging
+
+from aqute import Aqute
+
+
+async def parse_port(value: str) -> int:
+    await asyncio.sleep(0.1)  # Simulate asynchronous I/O.
+    return int(value)
+
+
+async def main() -> None:
+    tasks = await Aqute(parse_port, workers_count=2).process_all(
+        ["443", "invalid", "8080"]
+    )
+    for task in tasks:
+        if task.error is not None:
+            logging.warning("Failed %r: %s", task.data, task.error)
+        else:
+            logging.info("Port: %s", task.unwrap())
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    asyncio.run(main())

--- a/examples/quickstart_errors.py
+++ b/examples/quickstart_errors.py
@@ -2,12 +2,13 @@
 
 import asyncio
 import logging
+from random import uniform
 
 from aqute import Aqute
 
 
 async def parse_port(value: str) -> int:
-    await asyncio.sleep(0.1)  # Simulate asynchronous I/O.
+    await asyncio.sleep(uniform(0.025, 0.1))  # Simulate asynchronous I/O.
     return int(value)
 
 

--- a/examples/quickstart_http.py
+++ b/examples/quickstart_http.py
@@ -1,0 +1,39 @@
+"""Fetch URLs with shared connections, rate limits, and transport retries."""
+
+import asyncio
+import logging
+
+import httpx
+
+from aqute import Aqute
+from aqute.ratelimiter import TokenBucketRateLimiter
+
+
+async def main() -> None:
+    urls = ["https://example.com/", "https://example.org/"]
+    async with httpx.AsyncClient(timeout=5.0) as client:
+
+        async def fetch(url: str) -> int:
+            response = await client.get(url)
+            response.raise_for_status()
+            return response.status_code
+
+        engine = Aqute(
+            fetch,
+            workers_count=4,
+            rate_limiter=TokenBucketRateLimiter(max_rate=5),
+            retry_count=2,
+            retry_delay=lambda _attempt, _error: 0.5,
+            specific_errors_to_retry=httpx.TransportError,
+        )
+        async with engine.iter_results(urls) as results:
+            async for task in results:
+                if task.error is not None:
+                    logging.warning("Failed %s: %s", task.data, task.error)
+                else:
+                    logging.info("%s: HTTP %s", task.data, task.unwrap())
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    asyncio.run(main())

--- a/examples/streaming.py
+++ b/examples/streaming.py
@@ -18,6 +18,7 @@ async def main() -> int:
             logger.info("Source closed")
 
     async def handle(value: int) -> int:
+        await asyncio.sleep(0.1)  # Simulate asynchronous I/O.
         return value * 2
 
     engine = Aqute(handle, workers_count=3)

--- a/examples/streaming.py
+++ b/examples/streaming.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import logging
+from random import uniform
 
 from aqute import Aqute
 
@@ -18,7 +19,7 @@ async def main() -> int:
             logger.info("Source closed")
 
     async def handle(value: int) -> int:
-        await asyncio.sleep(0.1)  # Simulate asynchronous I/O.
+        await asyncio.sleep(uniform(0.025, 0.1))  # Simulate asynchronous I/O.
         return value * 2
 
     engine = Aqute(handle, workers_count=3)


### PR DESCRIPTION
The README Quickstart previously showed only a partial call and required readers to follow links for runnable examples. Add installation instructions and four complete examples covering ordered batches, per-item failures, streaming with early exit, and HTTP requests with rate limits and transport retries.

Keep the documentation Quickstart aligned with the executable sources. Simulate asynchronous I/O in the local examples with `asyncio.sleep(uniform(0.025, 0.1))`, explain result and cleanup behavior, and remove obsolete maintenance-version links from the current documentation.
