### PR TITLE
fix: preserve replies after cancelled admission and add usage recipes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+- Fix cancelled submissions to a full input queue leaving later results
+  unpublished. Admission and its task count now complete together, so cancelling
+  the submitting caller does not lose track of work already queued.
+
 ## 0.10.0 - 2026-09-08
 
 ### Breaking changes from 0.9.2

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install lint ruff-check-format ruff ty format test coverage docs check build wheel-smoke
+.PHONY: install lint ruff-check-format ruff ty format test coverage docs check build wheel-smoke sync-examples check-examples
 
 SMOKE_PYTHON ?= 3.11
 
@@ -31,7 +31,13 @@ coverage:
 	uv run --locked coverage html
 	uv run --locked genbadge coverage --local -i reports/coverage/coverage.xml -o reports/coverage/coverage.svg
 
-docs:
+sync-examples:
+	uv run --locked python scripts/sync_examples.py
+
+check-examples:
+	uv run --locked python scripts/sync_examples.py --check
+
+docs: check-examples
 	uv run --locked mkdocs build --strict
 
 check: lint coverage docs

--- a/README.md
+++ b/README.md
@@ -11,8 +11,10 @@ offload them to threads or processes.
 Use it for API ingestion and backfills, infrastructure automation, or independent
 remote inference and evaluation requests. Your application owns retry safety,
 checkpoints, token budgets, and provider policy. See
-[when to choose Aqute](https://insomnes.github.io/aqute/#when-to-choose-aqute)
-for a short comparison with plain asyncio and aiometer.
+[LLM batch inference](https://insomnes.github.io/aqute/llm_inference/) for an offline
+example with token-cost admission, shared throttling pauses, and checkpoints.
+For a comparison with plain asyncio, aiometer, and broker-backed queues, see
+[when to choose Aqute](https://insomnes.github.io/aqute/#when-to-choose-aqute).
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -282,6 +282,7 @@ retries, shutdown, counters, and migration from 0.9.2. The
 [changelog](https://github.com/insomnes/aqute/blob/main/CHANGELOG.md) collects the breaking changes and method renames. Full examples cover
 [streaming](https://insomnes.github.io/aqute/streaming/), [bounded HTTP processing](https://insomnes.github.io/aqute/http_client/),
 [manual result draining](https://insomnes.github.io/aqute/manual_drain/),
+[per-caller request pools](https://insomnes.github.io/aqute/request_pool/),
 and [service shutdown](https://insomnes.github.io/aqute/service_shutdown/).
 
 The [documentation source](https://github.com/insomnes/aqute/blob/main/docs/index.md)

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ The HTTP handler awaits real network I/O.
 Start here when the full result list fits in memory. The handler receives
 one input item per call; `workers_count=4` permits up to four concurrent handlers.
 
+<!-- example: examples/quickstart.py -->
 ```python
 """Run a finite batch and receive results in input order."""
 
@@ -65,6 +66,7 @@ if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO)
     logging.info("Results: %s", asyncio.run(main()))
 ```
+<!-- /example -->
 
 The result is `[0, 2, 4, 6, 8, 10, 12, 14, 16, 18]`. `process_all()` returns
 completed task objects in input order. `task.unwrap()` returns the handler value
@@ -76,6 +78,7 @@ it does not stop the batch on its first failure.
 Inspect `task.error` when one bad item must not prevent you from using the
 other results. This example uses local conversion to make a failure reproducible.
 
+<!-- example: examples/quickstart_errors.py -->
 ```python
 """Report each failed item and keep the successful results."""
 
@@ -106,6 +109,7 @@ if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO)
     asyncio.run(main())
 ```
+<!-- /example -->
 
 This logs ports `443` and `8080`, plus a failure for `"invalid"`. Handler
 failures are stored on completed tasks; retries are disabled by default.
@@ -118,6 +122,7 @@ Use `iter_results()` to consume results as they complete without collecting
 the full output. This example takes an asynchronous input source and stops
 after three results.
 
+<!-- example: examples/streaming.py -->
 ```python
 """Consume bounded streaming results and stop early with managed cleanup."""
 
@@ -160,6 +165,7 @@ if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO)
     logging.info("Results: %s consumed", asyncio.run(main()))
 ```
+<!-- /example -->
 
 Results arrive in completion order, which can differ from input order.
 Leaving `async with` awaits producer and worker cleanup, including after `break`
@@ -183,6 +189,7 @@ python -m pip install aqute==0.10.0 httpx
 Keep one client open around the managed result stream so workers finish cleanup
 before their connections close.
 
+<!-- example: examples/quickstart_http.py -->
 ```python
 """Fetch URLs with shared connections, rate limits, and transport retries."""
 
@@ -224,6 +231,7 @@ if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO)
     asyncio.run(main())
 ```
+<!-- /example -->
 
 `workers_count=4` limits concurrent handlers. The limiter spaces attempt
 starts by at least 0.2 seconds, including retries. `retry_count=2` allows at most
@@ -276,8 +284,9 @@ retries, shutdown, counters, and migration from 0.9.2. The
 [manual result draining](https://insomnes.github.io/aqute/manual_drain/),
 and [service shutdown](https://insomnes.github.io/aqute/service_shutdown/).
 
-The [documentation source](https://github.com/insomnes/aqute/blob/main/docs/index.md) includes code directly from these
-runnable files when built. To build and view the site locally:
+The [documentation source](https://github.com/insomnes/aqute/blob/main/docs/index.md)
+contains synchronized copies of the runnable examples, visible on GitHub and the
+documentation site. To build and view the site locally:
 
 ```bash
 uv sync --locked

--- a/aqute/engine.py
+++ b/aqute/engine.py
@@ -253,8 +253,18 @@ class Aqute(Generic[TData, TResult]):
             )
         if load is None or not self._foreman.in_queue.full():
             await self._foreman.add_task(task)
+            self._added_tasks_count += 1
+            self._load_changed.set()
         else:
-            admission = asyncio.create_task(self._foreman.add_task(task))
+
+            async def admit() -> None:
+                # Count the item before cancellation can resume its caller.
+                # The load task below already supervises worker failure.
+                await self._foreman.in_queue.put(task)
+                self._added_tasks_count += 1
+                self._load_changed.set()
+
+            admission = asyncio.create_task(admit())
             try:
                 await asyncio.wait(
                     (admission, load), return_when=asyncio.FIRST_COMPLETED
@@ -269,9 +279,6 @@ class Aqute(Generic[TData, TResult]):
                 admission.cancel()
                 with contextlib.suppress(asyncio.CancelledError):
                     await admission
-
-        self._added_tasks_count += 1
-        self._load_changed.set()
 
         return task_id
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -40,8 +40,15 @@ The site uses [Material for MkDocs](https://squidfunk.github.io/mkdocs-material/
 with system fonts. Its dependencies are included in the locked development environment.
 Run commands from the repository root. `make docs` builds the site in `site/`;
 `uv run --locked mkdocs serve` provides a local preview at
-`http://127.0.0.1:8000/aqute/`. The documentation includes the actual files in
-`examples/`. Missing source files fail the build.
+`http://127.0.0.1:8000/aqute/`. The Markdown files contain full copies of the source
+in `examples/`, so the code is also visible when reading the files on GitHub.
+HTML `example` and `/example` comments mark each generated block; the opening
+comment names its source path, such as `examples/quickstart.py`. Keep each marker
+on its own line. Edit the Python source, then run `make sync-examples` to update
+every marked copy in `README.md` and `docs/**/*.md`. Text outside those blocks is
+preserved. `make check-examples` checks without writing and reports outdated
+copies, missing sources, or malformed markers. Both `make docs` and `make check`
+run it, including in CI.
 
 ## Documentation publication
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -13,6 +13,7 @@ uv run --locked python -m examples.quickstart
 uv run --locked python -m examples.streaming
 uv run --locked python -m examples.retry_progress
 uv run --locked python -m examples.http_client
+uv run --locked python -m examples.llm_inference
 uv run --locked python -m examples.manual_drain
 uv run --locked python -m examples.service_shutdown
 ```
@@ -20,7 +21,8 @@ uv run --locked python -m examples.service_shutdown
 `make check` runs Ruff formatting and lint checks, ty, pytest with coverage, and a
 strict documentation build.
 The example tests verify returned values, failures, and cleanup. Entrypoint checks
-execute `quickstart`, `streaming`, `retry_progress`, `http_client`, and `manual_drain`.
+execute `quickstart`, `streaming`, `retry_progress`, `http_client`, `llm_inference`,
+and `manual_drain`.
 Commands use `uv.lock`; update dependencies with `uv lock --upgrade` and verify them with
 `make check`. CI tests Python 3.11, 3.12, 3.13, and 3.14.
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -14,6 +14,7 @@ uv run --locked python -m examples.streaming
 uv run --locked python -m examples.retry_progress
 uv run --locked python -m examples.http_client
 uv run --locked python -m examples.llm_inference
+uv run --locked python -m examples.request_pool
 uv run --locked python -m examples.manual_drain
 uv run --locked python -m examples.service_shutdown
 ```
@@ -21,7 +22,7 @@ uv run --locked python -m examples.service_shutdown
 `make check` runs Ruff formatting and lint checks, ty, pytest with coverage, and a
 strict documentation build.
 The example tests verify returned values, failures, and cleanup. Entrypoint checks
-execute `quickstart`, `streaming`, `retry_progress`, `http_client`, `llm_inference`,
+execute `quickstart`, `streaming`, `retry_progress`, `http_client`, `llm_inference`, `request_pool`,
 and `manual_drain`.
 Commands use `uv.lock`; update dependencies with `uv lock --upgrade` and verify them with
 `make check`. CI tests Python 3.11, 3.12, 3.13, and 3.14.

--- a/docs/http_client.md
+++ b/docs/http_client.md
@@ -40,9 +40,196 @@ you define the callback in the same file.
 
 ## Runnable source
 
+<!-- example: examples/http_client.py -->
 ```python
---8<-- "examples/http_client.py"
+"""Use one shared HTTPX client; main() runs an offline transport demonstration."""
+
+import asyncio
+import logging
+import math
+from collections.abc import AsyncIterable, Iterable
+from email.utils import parsedate_to_datetime
+from functools import partial
+from time import monotonic, time
+
+import httpx
+
+from aqute import Aqute
+from aqute.ratelimiter import PausableRateLimiter, TokenBucketRateLimiter
+from examples.retry_progress import retry_delay
+
+logger = logging.getLogger(__name__)
+TOO_MANY_REQUESTS = 429
+
+
+class RateLimitedError(httpx.HTTPStatusError):
+    """Select HTTP 429 for retries without retrying other HTTP status errors."""
+
+
+def retry_after_seconds(value: str | None) -> float:
+    """Accept nonnegative numeric seconds or an HTTP-date; default to one second.
+
+    Missing, malformed, negative, or nonfinite values use the fallback. Past
+    HTTP dates return zero. HTTP-date conversion uses wall time only here;
+    PausableRateLimiter stores the resulting delay on the monotonic clock.
+    """
+    if value is None:
+        return 1.0
+    try:
+        seconds = float(value)
+    except ValueError:
+        try:
+            deadline = parsedate_to_datetime(value)
+            if deadline.tzinfo is None:
+                return 1.0
+            return max(0.0, deadline.timestamp() - time())
+        except (TypeError, ValueError, OverflowError):
+            return 1.0
+    return seconds if math.isfinite(seconds) and seconds >= 0 else 1.0
+
+
+def http_retry_delay(failed_attempt: int, error: Exception) -> float:
+    """Keep per-worker retry delay for the comparison and transport backoff."""
+    if isinstance(error, RateLimitedError):
+        return retry_after_seconds(error.response.headers.get("Retry-After"))
+    return retry_delay(failed_attempt, error)
+
+
+async def fetch_page(
+    client: httpx.AsyncClient, url: str, limiter: PausableRateLimiter | None
+) -> str:
+    """Pause shared admission on 429; None demonstrates only per-worker delay."""
+    response = await client.get(url)
+    try:
+        response.raise_for_status()
+    except httpx.HTTPStatusError as error:
+        if response.status_code != TOO_MANY_REQUESTS:
+            raise
+        if limiter is not None:
+            limiter.pause_for(retry_after_seconds(response.headers.get("Retry-After")))
+        raise RateLimitedError(
+            str(error), request=error.request, response=error.response
+        ) from error
+    return response.text
+
+
+async def fetch_pages(
+    urls: Iterable[str] | AsyncIterable[str],
+    *,
+    transport: httpx.AsyncBaseTransport | None = None,
+) -> int:
+    """Log pages as they complete; raise the first observed terminal error."""
+    limiter = PausableRateLimiter(TokenBucketRateLimiter(max_rate=10))
+    async with httpx.AsyncClient(timeout=5.0, transport=transport) as client:
+
+        async def fetch(url: str) -> str:
+            return await fetch_page(client, url, limiter)
+
+        engine = Aqute(
+            fetch,
+            workers_count=4,
+            rate_limiter=limiter,
+            retry_count=2,
+            retry_delay=http_retry_delay,
+            specific_errors_to_retry=(httpx.TransportError, RateLimitedError),
+        )
+        completed = 0
+        async with engine.iter_results(urls) as results:
+            async for task in results:
+                # Replace this log with application-owned parsing or persistence.
+                logger.info("Fetched %s: %s", task.data, task.unwrap())
+                completed += 1
+        return completed
+
+
+async def compare_throttling() -> None:
+    """Compare eight workers against one 300 ms throttle window, offline.
+
+    The transport responds immediately, before the next paced admission. Real
+    requests already in flight can produce more 429s after a pause is set.
+    These request counts do not predict throughput for a real service.
+    """
+    workers = 8
+    urls = [f"https://example.test/jobs/{value}" for value in range(40)]
+    for shared_pause in (False, True):
+        throttled = 0
+        window_end = 0.0
+
+        def respond(request: httpx.Request) -> httpx.Response:
+            nonlocal throttled, window_end
+            if window_end == 0:
+                window_end = monotonic() + 0.3
+            if monotonic() < window_end:
+                throttled += 1
+                return httpx.Response(429, headers={"Retry-After": "1"})
+            return httpx.Response(200, text=request.url.path)
+
+        inner = TokenBucketRateLimiter(max_rate=100)
+        limiter = PausableRateLimiter(inner) if shared_pause else None
+        async with httpx.AsyncClient(transport=httpx.MockTransport(respond)) as client:
+            engine = Aqute(
+                partial(fetch_page, client, limiter=limiter),
+                workers_count=workers,
+                rate_limiter=limiter if limiter is not None else inner,
+                retry_count=2,
+                retry_delay=http_retry_delay,
+                specific_errors_to_retry=(httpx.TransportError, RateLimitedError),
+            )
+            started = monotonic()
+            completed = retries = 0
+            async with engine.iter_results(urls) as results:
+                async for task in results:
+                    task.unwrap()
+                    completed += 1
+                    retries = engine.counters.retries
+            logger.info(
+                "Throttle comparison: shared_pause=%s workers=%s pages=%s "
+                "throttled_requests=%s retries=%s elapsed=%.3fs",
+                shared_pause,
+                workers,
+                completed,
+                throttled,
+                retries,
+                monotonic() - started,
+            )
+
+
+async def main() -> int:
+    failed_once = False
+
+    def respond(request: httpx.Request) -> httpx.Response:
+        nonlocal failed_once
+        if request.url.path == "/jobs/1" and not failed_once:
+            failed_once = True
+            raise httpx.ConnectError("temporary connection failure", request=request)
+        if request.url.path == "/unavailable":
+            return httpx.Response(503)
+        return httpx.Response(200, text=request.url.path)
+
+    completed = await fetch_pages(
+        ("https://example.test/jobs/1", "https://example.test/jobs/2"),
+        transport=httpx.MockTransport(respond),
+    )
+    try:
+        await fetch_pages(
+            ("https://example.test/unavailable",),
+            transport=httpx.MockTransport(respond),
+        )
+    except httpx.HTTPStatusError as error:
+        logger.error(
+            "Terminal HTTP %s for %s; run stopped",
+            error.response.status_code,
+            error.request.url,
+        )
+    return completed
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    asyncio.run(compare_throttling())
+    logging.info("Results: %s pages", asyncio.run(main()))
 ```
+<!-- /example -->
 
 ## Limits and outcomes
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,6 +12,9 @@ Typical uses are API ingestion and backfills, infrastructure automation, and
 independent remote inference or evaluation requests. Your application owns retry
 safety, checkpoints, token budgets, and provider policy.
 
+The [LLM batch inference example](llm_inference.md) shows application-owned
+token-cost admission, shared throttling pauses, and checkpoints without a vendor SDK.
+
 ## Installation
 
 These pages and examples cover the 0.10.0 API. With Python 3.11+, install Aqute:
@@ -153,6 +156,7 @@ application ownership rules.
 | Plain asyncio | [`gather()`](https://docs.python.org/3/library/asyncio-task.html#asyncio.gather) collects results in input order. [`TaskGroup`](https://docs.python.org/3/library/asyncio-task.html#task-groups) awaits its tasks on context exit. | A small finite batch only needs concurrent calls, or your application already owns retries and flow control. |
 | [aiometer](https://github.com/florimondmanca/aiometer#usage) | `max_at_once` limits concurrent tasks; `max_per_second` limits starts per second. `run_all()` collects ordered results; `amap()` streams results as they become available. It supports asyncio and Trio. | You need concurrency and start-rate limits with result collection, and prefer to keep retry policy in your handler. |
 | Aqute | The [worker-pool API](usage.md) combines retry filters and delays, per-task success or error outcomes, synchronous or asynchronous input, and explicit shutdown. | Repeated I/O jobs need these controls together, such as an ingestion run that retries selected failures and records each terminal outcome. |
+| Broker-backed queues ([arq](https://arq-docs.helpmanual.io/), [Taskiq](https://taskiq-python.github.io/), [Dramatiq](https://dramatiq.io/), [Celery](https://docs.celeryq.dev/)) | Workers exchange tasks through a configured broker; deployment and delivery guarantees depend on the chosen system. Aqute runs in-process and needs no broker infrastructure. | Work must outlive the submitting process or run across independently deployed workers, and you can operate the broker and workers. |
 
 For infrastructure changes, retries can repeat side effects; the application must
 decide which operations are safe to repeat. For remote inference, Aqute schedules

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,9 +38,34 @@ The HTTP handler awaits real network I/O.
 Start here when the full result list fits in memory. The handler receives
 one input item per call; `workers_count=4` permits up to four concurrent handlers.
 
+<!-- example: examples/quickstart.py -->
 ```python
---8<-- "examples/quickstart.py"
+"""Run a finite batch and receive results in input order."""
+
+import asyncio
+import logging
+from random import uniform
+
+from aqute import Aqute
+
+
+async def handle(value: int) -> int:
+    await asyncio.sleep(uniform(0.025, 0.1))  # Simulate asynchronous I/O.
+    return value * 2
+
+
+async def main() -> list[int]:
+    tasks = await Aqute(handle, workers_count=4).process_all(range(10))
+    values = [task.unwrap() for task in tasks]
+    assert values == [value * 2 for value in range(10)]
+    return values
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    logging.info("Results: %s", asyncio.run(main()))
 ```
+<!-- /example -->
 
 The result is `[0, 2, 4, 6, 8, 10, 12, 14, 16, 18]`. `process_all()` returns
 completed task objects in input order. `task.unwrap()` returns the handler value
@@ -52,9 +77,38 @@ it does not stop the batch on its first failure.
 Inspect `task.error` when one bad item must not prevent you from using the
 other results. This example uses local conversion to make a failure reproducible.
 
+<!-- example: examples/quickstart_errors.py -->
 ```python
---8<-- "examples/quickstart_errors.py"
+"""Report each failed item and keep the successful results."""
+
+import asyncio
+import logging
+from random import uniform
+
+from aqute import Aqute
+
+
+async def parse_port(value: str) -> int:
+    await asyncio.sleep(uniform(0.025, 0.1))  # Simulate asynchronous I/O.
+    return int(value)
+
+
+async def main() -> None:
+    tasks = await Aqute(parse_port, workers_count=2).process_all(
+        ["443", "invalid", "8080"]
+    )
+    for task in tasks:
+        if task.error is not None:
+            logging.warning("Failed %r: %s", task.data, task.error)
+        else:
+            logging.info("Port: %s", task.unwrap())
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    asyncio.run(main())
 ```
+<!-- /example -->
 
 This logs ports `443` and `8080`, plus a failure for `"invalid"`. Handler
 failures are stored on completed tasks; retries are disabled by default.
@@ -67,9 +121,50 @@ Use `iter_results()` to consume results as they complete without collecting
 the full output. This example takes an asynchronous input source and stops
 after three results.
 
+<!-- example: examples/streaming.py -->
 ```python
---8<-- "examples/streaming.py"
+"""Consume bounded streaming results and stop early with managed cleanup."""
+
+import asyncio
+import logging
+from random import uniform
+
+from aqute import Aqute
+
+logger = logging.getLogger(__name__)
+RESULT_LIMIT = 3
+
+
+async def main() -> int:
+    async def source():
+        try:
+            for value in range(100):
+                yield value
+        finally:
+            logger.info("Source closed")
+
+    async def handle(value: int) -> int:
+        await asyncio.sleep(uniform(0.025, 0.1))  # Simulate asynchronous I/O.
+        return value * 2
+
+    engine = Aqute(handle, workers_count=3)
+    completed = 0
+    async with engine.iter_results(source()) as results:
+        async for task in results:
+            # Replace this log with application-owned processing or persistence.
+            logger.info("Result for %s: %s", task.data, task.unwrap())
+            completed += 1
+            if completed == RESULT_LIMIT:
+                break
+    # Context exit has awaited producer and worker cleanup.
+    return completed
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    logging.info("Results: %s consumed", asyncio.run(main()))
 ```
+<!-- /example -->
 
 Results arrive in completion order, which can differ from input order.
 Leaving `async with` awaits producer and worker cleanup, including after `break`
@@ -93,9 +188,49 @@ python -m pip install aqute==0.10.0 httpx
 Keep one client open around the managed result stream so workers finish cleanup
 before their connections close.
 
+<!-- example: examples/quickstart_http.py -->
 ```python
---8<-- "examples/quickstart_http.py"
+"""Fetch URLs with shared connections, rate limits, and transport retries."""
+
+import asyncio
+import logging
+
+import httpx
+
+from aqute import Aqute
+from aqute.ratelimiter import TokenBucketRateLimiter
+
+
+async def main() -> None:
+    urls = ["https://example.com/", "https://example.org/"]
+    async with httpx.AsyncClient(timeout=5.0) as client:
+
+        async def fetch(url: str) -> int:
+            response = await client.get(url)
+            response.raise_for_status()
+            return response.status_code
+
+        engine = Aqute(
+            fetch,
+            workers_count=4,
+            rate_limiter=TokenBucketRateLimiter(max_rate=5),
+            retry_count=2,
+            retry_delay=lambda _attempt, _error: 0.5,
+            specific_errors_to_retry=httpx.TransportError,
+        )
+        async with engine.iter_results(urls) as results:
+            async for task in results:
+                if task.error is not None:
+                    logging.warning("Failed %s: %s", task.data, task.error)
+                else:
+                    logging.info("%s: HTTP %s", task.data, task.unwrap())
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    asyncio.run(main())
 ```
+<!-- /example -->
 
 `workers_count=4` limits concurrent handlers. The limiter spaces attempt
 starts by at least 0.2 seconds, including retries. `retry_count=2` allows at most

--- a/docs/index.md
+++ b/docs/index.md
@@ -281,6 +281,8 @@ stream with finite queue defaults. `fetch_pages()` returns a count instead of
 retaining every body. Queues bound items, not payload bytes or application data.
 The same source provides an explicit callable path for real requests.
 
+For independent callers awaiting their own replies, see the
+[per-caller request pool](request_pool.md).
 See [For coding agents](usage.md#for-coding-agents) for helper selection and
 application ownership rules.
 

--- a/docs/llm_inference.md
+++ b/docs/llm_inference.md
@@ -42,8 +42,11 @@ protocol in application code. Its cost callback reads `task.data` and reserves
 `estimated_input_tokens + max_tokens` before every attempt, including retries.
 The bucket starts full, refills continuously at 600 tokens per minute, and holds
 at most 600 tokens. One request's positive estimated cost must fit that capacity;
-an invalid cost raises `ValueError` and stops the run. Initial bursts are possible:
-this token bucket does not enforce a strict rolling-minute ceiling.
+an invalid cost raises `ValueError`. Through Aqute, it stops the run inside the
+worker `ExceptionGroup`; see [limiter failures](usage.md#errors-retries-and-timeouts).
+Initial bursts are possible: a full bucket can admit up to 1,200 estimated tokens
+in its first minute (600 initially plus 600 refilled). This token bucket does not
+enforce a strict rolling-minute ceiling.
 
 This is an **upper-bound estimate without refund**, conditional on the input
 estimate covering the actual input and `max_tokens` bounding the counted output.
@@ -96,7 +99,9 @@ and include the model and relevant request configuration in that key. A crash
 after inference but before persistence can repeat a request; this example does
 not provide exactly-once execution or a durable queue. Application checkpoints
 also retain data outside Aqute's queue bounds. Each batch creates a fresh limiter,
-so restarting a batch resets the local budget and shared pause.
+so restarting a batch resets the local budget and shared pause. Frequent short
+batches can therefore exceed the intended aggregate budget; share a limiter
+across batches in an application that needs continuous admission accounting.
 
 The managed result stream waits for producer and worker cleanup before the HTTP
 client closes. This requires cooperative cancellation. The example buffers each

--- a/docs/llm_inference.md
+++ b/docs/llm_inference.md
@@ -1,0 +1,103 @@
+# LLM batch inference
+
+Use Aqute for independent remote inference requests when the application needs
+bounded concurrency, selected retries, and incremental results. This example adds
+a token-cost budget to the [HTTP recipe](http_client.md). It uses HTTPX directly;
+it does not require a vendor SDK, credentials, or a running model server.
+
+From a development checkout, run it offline:
+
+```bash
+uv run --locked python -m examples.llm_inference
+```
+
+The mock endpoint returns chat-completions-shaped JSON with a `usage` field.
+It delays responses by 25–100 ms, returns one HTTP 429 with `Retry-After: 1`,
+then completes three classifications. A second run skips the checkpointed inputs
+and makes no requests. The model name, endpoint, input-token estimates, and usage
+values are placeholders for this demonstration.
+
+## Runnable source
+
+```python
+--8<-- "examples/llm_inference.py"
+```
+
+The checkout provides `httpx` in its development dependencies. To adapt the source
+outside the checkout, install `aqute==0.10.0` and `httpx`, and replace the endpoint,
+model, credentials, and token estimates with your application's configuration.
+The source imports `RateLimitedError` and `retry_after_seconds` from
+`examples.http_client`; copy those definitions from the [HTTP source](http_client.md#runnable-source)
+or supply equivalents. The `examples` package is not installed with Aqute.
+
+## Requests and token budgets
+
+RPM counts requests per minute; TPM counts tokens per minute. Limiting request
+starts alone does not limit tokens when prompts and output lengths differ.
+`workers_count=3` limits occupied workers independently of either quota.
+This example controls estimated TPM; it does not add a separate RPM limiter.
+
+`TokenCostLimiter` implements the public `RateLimiter.acquire(name, task)`
+protocol in application code. Its cost callback reads `task.data` and reserves
+`estimated_input_tokens + max_tokens` before every attempt, including retries.
+The bucket starts full, refills continuously at 600 tokens per minute, and holds
+at most 600 tokens. One request's positive estimated cost must fit that capacity;
+an invalid cost raises `ValueError` and stops the run. Initial bursts are possible:
+this token bucket does not enforce a strict rolling-minute ceiling.
+
+This is an **upper-bound estimate without refund**, conditional on the input
+estimate covering the actual input and `max_tokens` bounding the counted output.
+The supplied estimates are illustrative, not a tokenizer. Provider accounting
+differs by vendor and can include other token categories or reservation rules;
+the local limiter is a budget model, not a mirror of provider accounting.
+The response's `usage` is logged only. Failed attempts keep their reservation,
+and a successful response does not return unused tokens to the bucket.
+
+This conservative reservation underutilizes the budget when `max_tokens` greatly
+exceeds typical output length. Set `max_tokens` to the task's required output
+size, not an arbitrary safety margin. A refund based on reported usage could be
+an application extension for free-form generation, but is not implemented here.
+
+## Retries and throttling
+
+`PausableRateLimiter` wraps the token limiter. On HTTP 429, the handler parses
+`Retry-After`, extends the shared pause, and raises a retryable error.
+Already admitted requests can still complete or return 429. Admissions delayed
+by the pause can resume together; this wrapper does not guarantee spacing after
+the pause. Header parsing and fallback behavior follow the [HTTP recipe](http_client.md#limits-and-outcomes).
+
+`retry_count=2` allows at most three attempts per input. Only HTTP 429 and
+`httpx.TransportError` are retried, with a 0.1-second per-worker delay in addition
+to any remaining admission wait. Other HTTP errors propagate through
+`task.unwrap()`, stop the batch, and leave earlier checkpoints intact.
+The five-second HTTPX timeout applies to network operations, not the whole batch,
+token-budget waits, or shared pauses.
+
+There is no SDK retry layer in this example; the real HTTP transport explicitly
+uses `retries=0`, and the mock transport performs no automatic retries.
+If you replace HTTPX with an SDK, disable its internal retries (often
+`max_retries=0`) and let Aqute retry. Otherwise one handler attempt can make
+multiple requests after a single token reservation. Disable retries on one side
+to avoid multiplication: `retry_count=0` avoids Aqute retries, but SDK-internal
+attempts would still bypass this limiter. Disable SDK retries when the limiter
+must see every attempt. Select retries with your provider's billing and duplicate
+request behavior in mind; a transport failure does not prove inference never ran.
+
+## Checkpoints and cleanup
+
+After consuming a successful result, the application stores
+`checkpoint[task.data] = output`. A new batch filters those inputs out before
+submission. This demonstration keeps the checkpoint in memory, keyed by the full
+`Prompt` value. It is lost on process exit and assumes unique inputs for a fixed
+model and configuration. Duplicate inputs within one run can still be submitted.
+
+For resumable application work, persist the output and completion key together
+and include the model and relevant request configuration in that key. A crash
+after inference but before persistence can repeat a request; this example does
+not provide exactly-once execution or a durable queue. Application checkpoints
+also retain data outside Aqute's queue bounds. Each batch creates a fresh limiter,
+so restarting a batch resets the local budget and shared pause.
+
+The managed result stream waits for producer and worker cleanup before the HTTP
+client closes. This requires cooperative cancellation. The example buffers each
+JSON response in memory; finite queues bound item counts, not response bytes.

--- a/docs/llm_inference.md
+++ b/docs/llm_inference.md
@@ -19,9 +19,175 @@ values are placeholders for this demonstration.
 
 ## Runnable source
 
+<!-- example: examples/llm_inference.py -->
 ```python
---8<-- "examples/llm_inference.py"
+"""Run an offline inference batch with token admission and application checkpoints."""
+
+import asyncio
+import json
+import logging
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
+from random import uniform
+from time import monotonic
+
+import httpx
+
+from aqute import Aqute, AquteTask
+from aqute.ratelimiter import PausableRateLimiter
+from examples.http_client import RateLimitedError, retry_after_seconds
+
+logger = logging.getLogger(__name__)
+TOO_MANY_REQUESTS = 429
+
+
+@dataclass(frozen=True)
+class Prompt:
+    text: str
+    estimated_input_tokens: int
+    max_tokens: int
+
+
+class TokenCostLimiter:
+    """Application-side token bucket; each attempt reserves its full estimated cost.
+
+    Use on one event loop. The bucket starts full and holds one minute's budget.
+    Failed attempts keep their reservation. No reconciliation with response usage.
+    """
+
+    def __init__(self, tokens_per_minute: int, cost: Callable[[Prompt], int]) -> None:
+        if tokens_per_minute <= 0:
+            raise ValueError("tokens_per_minute must be positive")
+        self._capacity = tokens_per_minute
+        self._rate = tokens_per_minute / 60
+        self._cost = cost
+        self._tokens = float(tokens_per_minute)
+        self._updated = monotonic()
+        self._lock = asyncio.Lock()
+
+    async def acquire(self, name: str = "", task: AquteTask | None = None) -> None:
+        if task is None:
+            raise ValueError("TokenCostLimiter requires task data")
+        cost = self._cost(task.data)
+        if not 0 < cost <= self._capacity:
+            raise ValueError("estimated cost must fit the positive token budget")
+        async with self._lock:
+            while True:
+                now = monotonic()
+                self._tokens = min(
+                    self._capacity, self._tokens + (now - self._updated) * self._rate
+                )
+                self._updated = now
+                if self._tokens >= cost:
+                    self._tokens -= cost
+                    return
+                logger.debug("%s waiting for a %s-token reservation", name, cost)
+                await asyncio.sleep((cost - self._tokens) / self._rate)
+
+
+async def infer_batch(
+    prompts: Iterable[Prompt],
+    checkpoint: dict[Prompt, str],
+    *,
+    transport: httpx.AsyncBaseTransport | None = None,
+) -> int:
+    """Skip checkpointed inputs; save each successful output; raise terminal errors."""
+    limiter = PausableRateLimiter(
+        TokenCostLimiter(
+            tokens_per_minute=600,
+            cost=lambda prompt: prompt.estimated_input_tokens + prompt.max_tokens,
+        )
+    )
+    # No SDK; disable HTTP transport retries so Aqute sees each attempt.
+    if transport is None:
+        transport = httpx.AsyncHTTPTransport(retries=0)
+    async with httpx.AsyncClient(transport=transport, timeout=5.0) as client:
+
+        async def infer(prompt: Prompt) -> str:
+            response = await client.post(
+                "https://inference.example.test/v1/chat/completions",
+                json={
+                    "model": "your-model-name",
+                    "messages": [{"role": "user", "content": prompt.text}],
+                    "max_tokens": prompt.max_tokens,
+                },
+            )
+            if response.status_code == TOO_MANY_REQUESTS:
+                delay = retry_after_seconds(response.headers.get("Retry-After"))
+                limiter.pause_for(delay)
+                logger.info("HTTP 429: pause admission for %.2fs", delay)
+                raise RateLimitedError(
+                    "inference throttled", request=response.request, response=response
+                )
+            response.raise_for_status()
+            body = response.json()
+            logger.info("Reported token usage: %s", body["usage"]["total_tokens"])
+            return body["choices"][0]["message"]["content"]
+
+        engine = Aqute(
+            infer,
+            workers_count=3,
+            rate_limiter=limiter,
+            retry_count=2,
+            specific_errors_to_retry=(httpx.TransportError, RateLimitedError),
+            retry_delay=lambda _attempt, _error: 0.1,
+        )
+        pending = (prompt for prompt in prompts if prompt not in checkpoint)
+        completed = 0
+        async with engine.iter_results(pending) as results:
+            async for task in results:
+                output = task.unwrap()
+                # Application-owned checkpoint: replace with durable persistence.
+                checkpoint[task.data] = output
+                completed += 1
+                logger.info("Completed %r: %s", task.data.text, output)
+        return completed
+
+
+async def main() -> int:
+    prompts = [
+        Prompt("Classify: service is healthy", 10, 8),
+        Prompt("Classify: connection refused", 12, 8),
+        Prompt("Classify: deployment completed", 10, 8),
+    ]
+    throttled_once = False
+
+    async def respond(request: httpx.Request) -> httpx.Response:
+        nonlocal throttled_once
+        await asyncio.sleep(uniform(0.025, 0.1))  # Simulate remote inference.
+        if not throttled_once:
+            throttled_once = True
+            return httpx.Response(429, headers={"Retry-After": "1"})
+        text = json.loads(request.content)["messages"][0]["content"]
+        label = "error" if "refused" in text else "ok"
+        return httpx.Response(
+            200,
+            json={
+                "choices": [{"message": {"role": "assistant", "content": label}}],
+                "usage": {
+                    "prompt_tokens": 8,
+                    "completion_tokens": 1,
+                    "total_tokens": 9,
+                },
+            },
+        )
+
+    checkpoint: dict[Prompt, str] = {}
+    completed = await infer_batch(
+        prompts, checkpoint, transport=httpx.MockTransport(respond)
+    )
+    resumed = await infer_batch(
+        prompts, checkpoint, transport=httpx.MockTransport(respond)
+    )
+    logger.info("Resume: %s new completions", resumed)
+    return completed
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    logging.info("Results: %s completions", asyncio.run(main()))
 ```
+<!-- /example -->
 
 The checkout provides `httpx` in its development dependencies. To adapt the source
 outside the checkout, install `aqute==0.10.0` and `httpx`, and replace the endpoint,

--- a/docs/manual_drain.md
+++ b/docs/manual_drain.md
@@ -42,12 +42,15 @@ async def main() -> list[tuple[str, int]]:
         # Results must be unlimited because consumption starts after finish().
         result_queue=asyncio.Queue(0),
     )
-    async with engine:
+    engine.start()  # Synchronous: awaiting this task would wait for the whole run.
+    try:
         for value in range(10):
             await engine.add_task(
                 value, task_id=f"job-{value}", task_priority=10 - value
             )
         await engine.finish()
+    finally:
+        await engine.stop()
 
     # Priority applies to pending tasks; it does not preempt active workers.
     return sorted((task.task_id, task.unwrap()) for task in engine.drain_results())

--- a/docs/manual_drain.md
+++ b/docs/manual_drain.md
@@ -19,6 +19,42 @@ workers. The example sorts the returned values by task ID and runs offline.
 uv run --locked python -m examples.manual_drain
 ```
 
+<!-- example: examples/manual_drain.py -->
 ```python
---8<-- "examples/manual_drain.py"
+"""Submit custom task IDs and priorities, then drain results after completion."""
+
+import asyncio
+import logging
+
+from aqute import Aqute
+
+
+async def handle(value: int) -> int:
+    return value * 2
+
+
+async def main() -> list[tuple[str, int]]:
+    # Use process_all() when custom task IDs and priorities are unnecessary.
+    engine = Aqute(
+        handle,
+        workers_count=2,
+        use_priority_queue=True,
+        # Results must be unlimited because consumption starts after finish().
+        result_queue=asyncio.Queue(0),
+    )
+    async with engine:
+        for value in range(10):
+            await engine.add_task(
+                value, task_id=f"job-{value}", task_priority=10 - value
+            )
+        await engine.finish()
+
+    # Priority applies to pending tasks; it does not preempt active workers.
+    return sorted((task.task_id, task.unwrap()) for task in engine.drain_results())
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    logging.info("Results: %s", asyncio.run(main()))
 ```
+<!-- /example -->

--- a/docs/request_pool.md
+++ b/docs/request_pool.md
@@ -11,6 +11,9 @@ Run the offline example from a development checkout:
 uv run --locked python -m examples.request_pool
 ```
 
+Use the checkout for this recipe: it fixes a bounded-submission cancellation bug
+that is still present in 0.10.0.
+
 The simulated handler sleeps for 25–100 ms. It returns a valid `None` for
 `empty`, raises a terminal `ValueError` for `invalid`, and throttles `retry` once.
 The throttle pauses new attempts for 150 ms before raising the retryable error.
@@ -152,6 +155,9 @@ up pending futures; callers still waiting for admission can receive `AquteError`
 The application must await its caller tasks too. Use an outer `asyncio.timeout`
 when the whole operation needs a deadline. Cleanup requires cooperative handlers.
 Unexpected processing failures propagate and can include an `ExceptionGroup`.
+Ordinary exceptions leaving the context body, including an unhandled `ask()` error,
+can also propagate as an `ExceptionGroup` from the background `TaskGroup`.
+Handle individual request errors inside the context, or use `except*` outside it.
 
 This context manager is example code, not an installed Aqute API or a durable
 request service. Copy it into application code and own the real client's lifetime.

--- a/docs/request_pool.md
+++ b/docs/request_pool.md
@@ -1,0 +1,159 @@
+# Per-caller request pool
+
+Use one long-lived engine when independent callers each need their own reply.
+The pool yields an `ask(prompt)` function: concurrent calls share workers, queues,
+and a rate limiter, but each awaits the outcome matching its own task ID.
+The same pool can serve later calls without restarting the engine.
+
+Run the offline example from a development checkout:
+
+```bash
+uv run --locked python -m examples.request_pool
+```
+
+The simulated handler sleeps for 25–100 ms. It returns a valid `None` for
+`empty`, raises a terminal `ValueError` for `invalid`, and throttles `retry` once.
+The throttle pauses new attempts for 150 ms before raising the retryable error.
+The demonstration collects four initial outcomes and one later reply: four
+successes, including `None`, and one failure. No credentials or server are needed.
+
+## Runnable source
+
+<!-- example: examples/request_pool.py -->
+```python
+"""Route replies from one long-lived engine to independent callers."""
+
+import asyncio
+import logging
+from collections.abc import AsyncIterator, Callable, Coroutine
+from contextlib import asynccontextmanager
+from random import uniform
+from typing import Any
+from uuid import uuid4
+
+from aqute import Aqute, AquteError, AquteTask
+from aqute.ratelimiter import PausableRateLimiter, TokenBucketRateLimiter
+
+
+@asynccontextmanager
+async def request_pool(
+    engine: Aqute[str, str | None],
+) -> AsyncIterator[Callable[[str], Coroutine[Any, Any, str | None]]]:
+    """Own a fresh engine; callers own their request tasks."""
+    pending: dict[str, asyncio.Future[AquteTask[str, str | None]]] = {}
+    accepting = True
+
+    async def ask(prompt: str) -> str | None:
+        if not accepting:
+            raise RuntimeError("Request pool is closed")
+        task_id = str(uuid4())
+        future = asyncio.get_running_loop().create_future()
+        pending[task_id] = future  # Register before submission can yield.
+        try:
+            await engine.add_task(prompt, task_id=task_id)
+            return (await future).unwrap()
+        finally:
+            pending.pop(task_id, None)
+            future.cancel()
+
+    async def collect() -> None:
+        while True:
+            try:
+                task = await engine.get_result()
+            except AquteError:
+                if not accepting:  # finish() ended the run during normal shutdown.
+                    return
+                raise
+            future = pending.get(task.task_id)
+            if future is not None and not future.done():
+                # Store the outcome; only its caller unwraps a terminal error.
+                future.set_result(task)
+
+    engine.start()  # Synchronous: do not await the background processing task here.
+    try:
+        async with asyncio.TaskGroup() as background:
+            background.create_task(collect())
+            try:
+                yield ask
+            finally:
+                accepting = False
+            await engine.finish()  # Keep the collector running while draining.
+    finally:
+        try:
+            await engine.stop()
+        finally:
+            for future in pending.values():
+                future.cancel()
+            pending.clear()
+
+
+class ThrottledError(Exception):
+    """Simulate a retryable remote throttle response."""
+
+
+async def main() -> list[str | None | BaseException]:
+    limiter = PausableRateLimiter(TokenBucketRateLimiter(max_rate=20))
+    throttled = False
+
+    async def handle(prompt: str) -> str | None:
+        nonlocal throttled
+        await asyncio.sleep(uniform(0.025, 0.1))
+        if prompt == "retry" and not throttled:
+            throttled = True
+            limiter.pause_for(0.15)  # Inside the handler, before the retryable error.
+            raise ThrottledError("Retry after 0.15 seconds")
+        if prompt == "invalid":
+            raise ValueError("Invalid prompt")
+        return None if prompt == "empty" else f"Reply to {prompt}"
+
+    engine = Aqute(
+        handle,
+        workers_count=3,
+        rate_limiter=limiter,
+        retry_count=2,
+        specific_errors_to_retry=ThrottledError,
+    )
+    async with request_pool(engine) as ask:
+        replies = await asyncio.gather(
+            *(ask(prompt) for prompt in ("first", "empty", "invalid", "retry")),
+            return_exceptions=True,
+        )
+        replies.append(await ask("later"))  # The same pool serves another caller.
+    return replies
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    replies = asyncio.run(main())
+    failures = sum(isinstance(reply, BaseException) for reply in replies)
+    logging.info("Results: %s replies, %s failure", len(replies) - failures, failures)
+```
+<!-- /example -->
+
+## Ownership and shutdown
+
+Pass a fresh engine and give this context exclusive ownership of its lifetime
+and result queue. Configure the handler, retry policy and limiter on that engine.
+The example starts it synchronously and keeps one consumer running until draining
+finishes. It registers each future before submission can yield, and stores the
+terminal task in that future. Only the matching caller calls `unwrap()`, which
+preserves `None` and raises that caller's terminal handler error.
+
+Stop producers and await their request tasks before leaving the context, as the
+demonstration does. Normal exit rejects later calls, finishes admitted work and
+drains replies. The default input capacity equals `workers_count`; excess callers
+can wait inside `add_task()`. Bound caller tasks or give admission a deadline;
+finite engine queues do not bound the application's caller count.
+
+Cancelling a caller removes its reply future. It does not cancel work already
+admitted to Aqute or undo remote side effects. Other callers continue normally.
+An exception or cancellation of the context owner cancels processing and cleans
+up pending futures; callers still waiting for admission can receive `AquteError`.
+The application must await its caller tasks too. Use an outer `asyncio.timeout`
+when the whole operation needs a deadline. Cleanup requires cooperative handlers.
+Unexpected processing failures propagate and can include an `ExceptionGroup`.
+
+This context manager is example code, not an installed Aqute API or a durable
+request service. Copy it into application code and own the real client's lifetime.
+For real HTTP errors and `Retry-After`, see the [HTTP recipe](http_client.md);
+for token budgets and SDK retry ownership, see [LLM inference](llm_inference.md).

--- a/docs/retry_progress.md
+++ b/docs/retry_progress.md
@@ -9,9 +9,73 @@ the same `retry_delay` callback.
 uv run --locked python -m examples.retry_progress
 ```
 
+<!-- example: examples/retry_progress.py -->
 ```python
---8<-- "examples/retry_progress.py"
+"""Bounded asynchronous input, retries, and progress counters."""
+
+import asyncio
+import logging
+from collections import Counter
+from random import uniform
+
+from aqute import Aqute
+
+logger = logging.getLogger(__name__)
+FAIL_ONCE = 3
+
+
+def retry_delay(failed_attempt: int, _error: Exception) -> float:
+    ceiling = min(5.0, 0.01 * 2 ** min(failed_attempt - 1, 10))
+    return uniform(0.0, ceiling)
+
+
+async def main() -> list[int]:
+    attempts: Counter[int] = Counter()
+
+    async def source():
+        for value in range(8):
+            yield value
+
+    async def handle(value: int) -> int:
+        attempts[value] += 1
+        if value == FAIL_ONCE and attempts[value] == 1:
+            raise ValueError("transient example failure")
+        return value * 2
+
+    engine = Aqute(
+        handle,
+        3,
+        input_task_queue_size=4,
+        result_queue=asyncio.Queue(4),
+        retry_count=2,
+        retry_delay=retry_delay,
+        specific_errors_to_retry=ValueError,
+    )
+    values = []
+    async with engine.iter_results(source()) as results:
+        async for task in results:
+            if task.error is not None:
+                raise task.error
+            assert task.result is not None
+            values.append(task.result)
+            counts = engine.counters
+            logger.info(
+                "Pending=%s running=%s succeeded=%s failed=%s retries=%s",
+                counts.pending,
+                counts.running,
+                counts.succeeded,
+                counts.failed,
+                counts.retries,
+            )
+    assert sorted(values) == [value * 2 for value in range(8)]
+    return values
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    logging.info("Results: %s", sorted(asyncio.run(main())))
 ```
+<!-- /example -->
 
 `retry_count=2` permits two extra attempts. This example selects `ValueError`;
 applications must select safe retry errors and operations for their own handlers.

--- a/docs/service_shutdown.md
+++ b/docs/service_shutdown.md
@@ -9,8 +9,96 @@ force a coroutine to terminate. The demonstration uses finite local work.
 uv run --locked python -m examples.service_shutdown
 ```
 
+<!-- example: examples/service_shutdown.py -->
 ```python
---8<-- "examples/service_shutdown.py"
+"""Stop input, drain bounded results under a deadline, then cancel if needed."""
+
+import asyncio
+import logging
+from collections.abc import Callable, Coroutine
+from typing import Any
+
+from aqute import Aqute, AquteError
+
+logger = logging.getLogger(__name__)
+SHUTDOWN_AFTER = 3
+
+
+async def serve(
+    handler: Callable[[int], Coroutine[Any, Any, int]],
+    *,
+    drain_timeout: float = 1.0,
+) -> tuple[list[int], bool]:
+    engine = Aqute(handler, 2, input_task_queue_size=2, result_queue=asyncio.Queue(2))
+    stop_input = asyncio.Event()
+    ready = asyncio.Event()
+    production_done = asyncio.Event()
+    submitted = 0
+    values: list[int] = []
+    timed_out = False
+
+    async def produce() -> None:
+        nonlocal submitted
+        try:
+            job_id = 0
+            while not stop_input.is_set():
+                await engine.add_task(job_id)
+                submitted += 1
+                job_id += 1
+                if submitted >= SHUTDOWN_AFTER:
+                    ready.set()
+        finally:
+            production_done.set()
+
+    async def collect() -> None:
+        while not production_done.is_set() or len(values) < submitted:
+            try:
+                task = await engine.get_result()
+            except AquteError:
+                if production_done.is_set() and len(values) == submitted:
+                    return
+                raise
+            if task.error is not None:
+                raise task.error
+            assert task.result is not None
+            values.append(task.result)
+            logger.info("Progress: %s", engine.counters)
+
+    async with engine, asyncio.TaskGroup() as group:
+        producer = group.create_task(produce())
+        collector = group.create_task(collect())
+        # In a service, wait for its shutdown signal here.
+        await ready.wait()
+        stop_input.set()
+        try:
+            async with asyncio.timeout(drain_timeout):
+                await producer  # Complete any submission already in flight.
+                await engine.finish()
+                await collector  # Results must drain while finish() waits.
+        except TimeoutError:
+            timed_out = True
+            producer.cancel()
+            collector.cancel()
+            await engine.stop()
+    return values, timed_out
+
+
+async def main() -> list[int]:
+    async def handle(job_id: int) -> int:
+        await asyncio.sleep(0.001)
+        return job_id
+
+    values, timed_out = await serve(handle)
+    assert not timed_out
+    assert sorted(values) == list(range(len(values)))
+    assert len(values) >= SHUTDOWN_AFTER
+    return values
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    logging.info("Results: %s", sorted(asyncio.run(main())))
 ```
+<!-- /example -->
 
 See [usage](usage.md) for the complete lifecycle and error contracts.

--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -10,9 +10,50 @@ From a development checkout, run this finite example offline:
 uv run --locked python -m examples.streaming
 ```
 
+<!-- example: examples/streaming.py -->
 ```python
---8<-- "examples/streaming.py"
+"""Consume bounded streaming results and stop early with managed cleanup."""
+
+import asyncio
+import logging
+from random import uniform
+
+from aqute import Aqute
+
+logger = logging.getLogger(__name__)
+RESULT_LIMIT = 3
+
+
+async def main() -> int:
+    async def source():
+        try:
+            for value in range(100):
+                yield value
+        finally:
+            logger.info("Source closed")
+
+    async def handle(value: int) -> int:
+        await asyncio.sleep(uniform(0.025, 0.1))  # Simulate asynchronous I/O.
+        return value * 2
+
+    engine = Aqute(handle, workers_count=3)
+    completed = 0
+    async with engine.iter_results(source()) as results:
+        async for task in results:
+            # Replace this log with application-owned processing or persistence.
+            logger.info("Result for %s: %s", task.data, task.unwrap())
+            completed += 1
+            if completed == RESULT_LIMIT:
+                break
+    # Context exit has awaited producer and worker cleanup.
+    return completed
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    logging.info("Results: %s consumed", asyncio.run(main()))
 ```
+<!-- /example -->
 
 The source yields integers without building an input list. Replace `source()`
 with your iterable or async iterable, and `handle()` with your async operation.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -199,6 +199,18 @@ A custom limiter implements `async acquire(name="", task=None)`. It must propaga
 cancellation. CPU-heavy or blocking work in a handler blocks the event loop;
 Aqute does not move it to threads or processes automatically.
 
+For a synchronous I/O handler, wrap the call in an async handler with
+`return await asyncio.to_thread(fn, item)`. The default executor caps its threads
+at `min(32, (cpu_count or 1) + 4)`: Python 3.11–3.12 uses `os.cpu_count()`, while
+Python 3.13+ uses `os.process_cpu_count()`. Effective concurrency can therefore be
+below `workers_count`. If needed, configure a custom `ThreadPoolExecutor(max_workers=...)`
+with `asyncio.get_running_loop().set_default_executor(executor)` before submitting
+work, and own its shutdown. See Python's [executor defaults](https://docs.python.org/3/library/concurrent.futures.html#concurrent.futures.ThreadPoolExecutor)
+and [`to_thread`](https://docs.python.org/3/library/asyncio-task.html#asyncio.to_thread).
+Cancellation or an Aqute timeout does not stop an already running thread; retries
+can overlap the original call, so use operation-level timeouts and safe retry
+policies. Threads generally do not make CPU-bound Python work parallel under the GIL.
+
 With `use_priority_queue=True`, pass `task_priority` to `add_task()`. Lower values
 run first among admitted pending tasks. Priority does not preempt an occupied
 worker. A worker retains its task through retries.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -145,7 +145,8 @@ limiter = SlidingRateLimiter(max_rate=5, time_period=0.2)
 ```
 
 The sliding limiter can grant all five permits together. A token bucket with
-`allow_burst=False` instead spaces grants by `time_period / max_rate` seconds.
+`allow_burst=False` (the default) instead spaces grants by
+`time_period / max_rate` seconds.
 These limits apply to limiter grants; a pause wrapper can delay handler starts
 after a grant, as described below.
 
@@ -156,9 +157,12 @@ from aqute.ratelimiter import PausableRateLimiter, TokenBucketRateLimiter
 
 limiter = PausableRateLimiter(TokenBucketRateLimiter(max_rate=10))
 engine = Aqute(handle, workers_count=4, rate_limiter=limiter)
-# Application code can call this after a throttle response:
+# Inside handle(), before raising a retryable throttle error:
 limiter.pause_for(2.0)
 ```
+
+Call `pause_for()` in the handler before raising the retryable throttle error;
+the result consumer receives only terminal outcomes and cannot pause earlier retries.
 
 `pause_for(seconds)` extends the pause from `time.monotonic()` now.
 `pause_until(deadline)` takes an absolute deadline from that same clock.
@@ -279,6 +283,11 @@ Start workers before filling a bounded input queue; otherwise `add_task()` raise
 `await add_task(data)` and consume results concurrently with `await get_result()`.
 Custom IDs use `task_id`; omitted IDs are generated. `drain_results()` removes currently available results without waiting.
 `get_result()` raises `AquteError` after normal completion when no results remain.
+While the run is active and the result queue is empty, `get_result()` waits for
+a result or run completion, with no timeout of its own.
+After start, a full input queue makes `add_task()` wait for capacity or run
+completion; default capacity `workers_count` can therefore block service callers
+inside submission, so bound concurrent callers or apply an admission timeout.
 
 Results use one shared queue. `get_result()` returns the next available result,
 not necessarily the result of the caller's last `add_task()`. For per-caller
@@ -311,8 +320,9 @@ input. A drain deadline requests cancellation; it cannot force an uncooperative
 coroutine to terminate. The example's caller receives whether draining timed out.
 In-process completion does not imply durable delivery.
 
-Completed results remain available after `stop()`. The engine can be reused; drain
-retained results before using a helper again. For lower-level worker queues,
+Completed results remain available after `stop()`. After `await stop()`, call
+`start()` again to reuse the same engine; `stop()` resets the run task and counters.
+Drain retained results before using a helper again. For lower-level worker queues,
 `aqute.worker.Foreman` exposes `start()`, `add_task(AquteTask(...))`,
 `get_handled_task()`, `finalize()`, and `stop()`. Consume finite result queues while
 waiting for `finalize()`.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -298,6 +298,8 @@ application-owned `asyncio.Future`. Register the future under a unique ID before
 submission. The application owns cancellation and cleanup of these futures,
 including submission failures and shutdown. Check `task.success` or use
 `task.unwrap()` when delivering results; a successful result can be `None`.
+The runnable [per-caller request pool](request_pool.md) shows this routing pattern,
+caller cancellation, and an engine that stays open for later requests.
 
 `finish_submitting()` signals that input submission is complete. `await finish()`
 also sends that signal and waits for processing. Stop producers before either
@@ -391,14 +393,16 @@ retains the old API for Python 3.9 and 3.10.
 For application code, [install Aqute](index.md#installation)
 with Python 3.11+ and import `Aqute` from `aqute`. The
 [canonical HTTP recipe](http_client.md) also requires `httpx`; the checkout's dev
-group includes it. Adapt that runnable source instead of reconstructing the API
-from older examples.
+group includes it. For independent callers sharing a long-lived engine, start
+with the [per-caller request pool](request_pool.md). Choose the example matching
+the application's input and result flow instead of reconstructing the API.
 
 | Application need | API |
 | --- | --- |
 | A finite batch with an ordered result list | `await engine.process_all(items)` |
 | Results in completion order, with bounded buffering and incremental consumption | `async with engine.iter_results(items) as results`, then iterate `results` inside the context |
 | Continuous submission with separate producer and consumer ownership | Follow [manual processing and shutdown](#manual-processing-and-shutdown) |
+| Independent callers each waiting for their own reply from a shared engine | Use the [per-caller request pool](request_pool.md) example |
 
 - Create a fresh engine for each helper run. The stream context waits for cleanup
   after completion, early exit, or failure. Keep the external client open around

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -285,8 +285,9 @@ Custom IDs use `task_id`; omitted IDs are generated. `drain_results()` removes c
 `get_result()` raises `AquteError` after normal completion when no results remain.
 While the run is active and the result queue is empty, `get_result()` waits for
 a result or run completion, with no timeout of its own.
-After start, a full input queue makes `add_task()` wait for capacity or run
-completion; default capacity `workers_count` can therefore block service callers
+After start, a full input queue makes `add_task()` wait for capacity;
+it raises `AquteError` if the run completes normally before admission.
+Default capacity `workers_count` can therefore block service callers
 inside submission, so bound concurrent callers or apply an admission timeout.
 
 Results use one shared queue. `get_result()` returns the next available result,

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -134,6 +134,21 @@ Available implementations are in `aqute.ratelimiter`:
 - `RandomizedIntervalRateLimiter` adds bounded random delays after rolling-cap waits.
 - `PausableRateLimiter` wraps any limiter with a shared monotonic pause.
 
+For `TokenBucketRateLimiter` and `SlidingRateLimiter`, `max_rate` applies over
+`time_period` seconds; the default period is one second. To allow five grants
+in each rolling 0.2-second window:
+
+```python
+from aqute.ratelimiter import SlidingRateLimiter
+
+limiter = SlidingRateLimiter(max_rate=5, time_period=0.2)
+```
+
+The sliding limiter can grant all five permits together. A token bucket with
+`allow_burst=False` instead spaces grants by `time_period / max_rate` seconds.
+These limits apply to limiter grants; a pause wrapper can delay handler starts
+after a grant, as described below.
+
 To pause attempt admission after service throttling, share one wrapper:
 
 ```python
@@ -253,12 +268,26 @@ group. See [HTTPX's async client guide](https://www.python-httpx.org/async/).
 
 ## Manual processing and shutdown
 
-Use the Aqute async context manager, or `start()` followed by `stop()`. Start workers
-before filling a bounded input queue; otherwise `add_task()` raises `AquteError`
-when the input queue is already full. With default limits, submit with
+Use the Aqute async context manager, or call `engine.start()` and later
+`await engine.stop()` in a `finally` block. `start()` is synchronous and returns
+the background `asyncio.Task`. Awaiting that task waits for the whole run to end;
+do not `await engine.start()` before submitting input. The
+[manual drain example](manual_drain.md) shows explicit start and cleanup.
+
+Start workers before filling a bounded input queue; otherwise `add_task()` raises
+`AquteError` when the input queue is already full. With default limits, submit with
 `await add_task(data)` and consume results concurrently with `await get_result()`.
 Custom IDs use `task_id`; omitted IDs are generated. `drain_results()` removes currently available results without waiting.
 `get_result()` raises `AquteError` after normal completion when no results remain.
+
+Results use one shared queue. `get_result()` returns the next available result,
+not necessarily the result of the caller's last `add_task()`. For per-caller
+responses, use one result consumer and route each task by `task.task_id` to an
+application-owned `asyncio.Future`. Register the future under a unique ID before
+`await add_task(data, task_id=...)`, because processing can finish during
+submission. The application owns cancellation and cleanup of these futures,
+including submission failures and shutdown. Check `task.success` or use
+`task.unwrap()` when delivering results; a successful result can be `None`.
 
 `finish_submitting()` signals that input submission is complete. `await finish()`
 also sends that signal and waits for processing. Stop producers before either

--- a/examples/llm_inference.py
+++ b/examples/llm_inference.py
@@ -1,0 +1,165 @@
+"""Run an offline inference batch with token admission and application checkpoints."""
+
+import asyncio
+import json
+import logging
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
+from random import uniform
+from time import monotonic
+
+import httpx
+
+from aqute import Aqute, AquteTask
+from aqute.ratelimiter import PausableRateLimiter
+from examples.http_client import RateLimitedError, retry_after_seconds
+
+logger = logging.getLogger(__name__)
+TOO_MANY_REQUESTS = 429
+
+
+@dataclass(frozen=True)
+class Prompt:
+    text: str
+    estimated_input_tokens: int
+    max_tokens: int
+
+
+class TokenCostLimiter:
+    """Application-side token bucket; each attempt reserves its full estimated cost.
+
+    Use on one event loop. The bucket starts full and holds one minute's budget.
+    Failed attempts keep their reservation. No reconciliation with response usage.
+    """
+
+    def __init__(self, tokens_per_minute: int, cost: Callable[[Prompt], int]) -> None:
+        if tokens_per_minute <= 0:
+            raise ValueError("tokens_per_minute must be positive")
+        self._capacity = tokens_per_minute
+        self._rate = tokens_per_minute / 60
+        self._cost = cost
+        self._tokens = float(tokens_per_minute)
+        self._updated = monotonic()
+        self._lock = asyncio.Lock()
+
+    async def acquire(self, name: str = "", task: AquteTask | None = None) -> None:
+        if task is None:
+            raise ValueError("TokenCostLimiter requires task data")
+        cost = self._cost(task.data)
+        if not 0 < cost <= self._capacity:
+            raise ValueError("estimated cost must fit the positive token budget")
+        async with self._lock:
+            while True:
+                now = monotonic()
+                self._tokens = min(
+                    self._capacity, self._tokens + (now - self._updated) * self._rate
+                )
+                self._updated = now
+                if self._tokens >= cost:
+                    self._tokens -= cost
+                    return
+                logger.debug("%s waiting for a %s-token reservation", name, cost)
+                await asyncio.sleep((cost - self._tokens) / self._rate)
+
+
+async def infer_batch(
+    prompts: Iterable[Prompt],
+    checkpoint: dict[Prompt, str],
+    *,
+    transport: httpx.AsyncBaseTransport | None = None,
+) -> int:
+    """Skip checkpointed inputs; save each successful output; raise terminal errors."""
+    limiter = PausableRateLimiter(
+        TokenCostLimiter(
+            tokens_per_minute=600,
+            cost=lambda prompt: prompt.estimated_input_tokens + prompt.max_tokens,
+        )
+    )
+    # No SDK; disable HTTP transport retries so Aqute sees each attempt.
+    if transport is None:
+        transport = httpx.AsyncHTTPTransport(retries=0)
+    async with httpx.AsyncClient(transport=transport, timeout=5.0) as client:
+
+        async def infer(prompt: Prompt) -> str:
+            response = await client.post(
+                "https://inference.example.test/v1/chat/completions",
+                json={
+                    "model": "your-model-name",
+                    "messages": [{"role": "user", "content": prompt.text}],
+                    "max_tokens": prompt.max_tokens,
+                },
+            )
+            if response.status_code == TOO_MANY_REQUESTS:
+                delay = retry_after_seconds(response.headers.get("Retry-After"))
+                limiter.pause_for(delay)
+                logger.info("HTTP 429: pause admission for %.2fs", delay)
+                raise RateLimitedError(
+                    "inference throttled", request=response.request, response=response
+                )
+            response.raise_for_status()
+            body = response.json()
+            logger.info("Reported token usage: %s", body["usage"]["total_tokens"])
+            return body["choices"][0]["message"]["content"]
+
+        engine = Aqute(
+            infer,
+            workers_count=3,
+            rate_limiter=limiter,
+            retry_count=2,
+            specific_errors_to_retry=(httpx.TransportError, RateLimitedError),
+            retry_delay=lambda _attempt, _error: 0.1,
+        )
+        pending = (prompt for prompt in prompts if prompt not in checkpoint)
+        completed = 0
+        async with engine.iter_results(pending) as results:
+            async for task in results:
+                output = task.unwrap()
+                # Application-owned checkpoint: replace with durable persistence.
+                checkpoint[task.data] = output
+                completed += 1
+                logger.info("Completed %r: %s", task.data.text, output)
+        return completed
+
+
+async def main() -> int:
+    prompts = [
+        Prompt("Classify: service is healthy", 10, 8),
+        Prompt("Classify: connection refused", 12, 8),
+        Prompt("Classify: deployment completed", 10, 8),
+    ]
+    throttled_once = False
+
+    async def respond(request: httpx.Request) -> httpx.Response:
+        nonlocal throttled_once
+        await asyncio.sleep(uniform(0.025, 0.1))  # Simulate remote inference.
+        if not throttled_once:
+            throttled_once = True
+            return httpx.Response(429, headers={"Retry-After": "1"})
+        text = json.loads(request.content)["messages"][0]["content"]
+        label = "error" if "refused" in text else "ok"
+        return httpx.Response(
+            200,
+            json={
+                "choices": [{"message": {"role": "assistant", "content": label}}],
+                "usage": {
+                    "prompt_tokens": 8,
+                    "completion_tokens": 1,
+                    "total_tokens": 9,
+                },
+            },
+        )
+
+    checkpoint: dict[Prompt, str] = {}
+    completed = await infer_batch(
+        prompts, checkpoint, transport=httpx.MockTransport(respond)
+    )
+    resumed = await infer_batch(
+        prompts, checkpoint, transport=httpx.MockTransport(respond)
+    )
+    logger.info("Resume: %s new completions", resumed)
+    return completed
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    logging.info("Results: %s completions", asyncio.run(main()))

--- a/examples/manual_drain.py
+++ b/examples/manual_drain.py
@@ -19,12 +19,15 @@ async def main() -> list[tuple[str, int]]:
         # Results must be unlimited because consumption starts after finish().
         result_queue=asyncio.Queue(0),
     )
-    async with engine:
+    engine.start()  # Synchronous: awaiting this task would wait for the whole run.
+    try:
         for value in range(10):
             await engine.add_task(
                 value, task_id=f"job-{value}", task_priority=10 - value
             )
         await engine.finish()
+    finally:
+        await engine.stop()
 
     # Priority applies to pending tasks; it does not preempt active workers.
     return sorted((task.task_id, task.unwrap()) for task in engine.drain_results())

--- a/examples/request_pool.py
+++ b/examples/request_pool.py
@@ -1,0 +1,106 @@
+"""Route replies from one long-lived engine to independent callers."""
+
+import asyncio
+import logging
+from collections.abc import AsyncIterator, Callable, Coroutine
+from contextlib import asynccontextmanager
+from random import uniform
+from typing import Any
+from uuid import uuid4
+
+from aqute import Aqute, AquteError, AquteTask
+from aqute.ratelimiter import PausableRateLimiter, TokenBucketRateLimiter
+
+
+@asynccontextmanager
+async def request_pool(
+    engine: Aqute[str, str | None],
+) -> AsyncIterator[Callable[[str], Coroutine[Any, Any, str | None]]]:
+    """Own a fresh engine; callers own their request tasks."""
+    pending: dict[str, asyncio.Future[AquteTask[str, str | None]]] = {}
+    accepting = True
+
+    async def ask(prompt: str) -> str | None:
+        if not accepting:
+            raise RuntimeError("Request pool is closed")
+        task_id = str(uuid4())
+        future = asyncio.get_running_loop().create_future()
+        pending[task_id] = future  # Register before submission can yield.
+        try:
+            await engine.add_task(prompt, task_id=task_id)
+            return (await future).unwrap()
+        finally:
+            pending.pop(task_id, None)
+            future.cancel()
+
+    async def collect() -> None:
+        while True:
+            try:
+                task = await engine.get_result()
+            except AquteError:
+                if not accepting:  # finish() ended the run during normal shutdown.
+                    return
+                raise
+            future = pending.get(task.task_id)
+            if future is not None and not future.done():
+                # Store the outcome; only its caller unwraps a terminal error.
+                future.set_result(task)
+
+    engine.start()  # Synchronous: do not await the background processing task here.
+    try:
+        async with asyncio.TaskGroup() as background:
+            background.create_task(collect())
+            try:
+                yield ask
+            finally:
+                accepting = False
+            await engine.finish()  # Keep the collector running while draining.
+    finally:
+        try:
+            await engine.stop()
+        finally:
+            for future in pending.values():
+                future.cancel()
+            pending.clear()
+
+
+class ThrottledError(Exception):
+    """Simulate a retryable remote throttle response."""
+
+
+async def main() -> list[str | None | BaseException]:
+    limiter = PausableRateLimiter(TokenBucketRateLimiter(max_rate=20))
+    throttled = False
+
+    async def handle(prompt: str) -> str | None:
+        nonlocal throttled
+        await asyncio.sleep(uniform(0.025, 0.1))
+        if prompt == "retry" and not throttled:
+            throttled = True
+            limiter.pause_for(0.15)  # Inside the handler, before the retryable error.
+            raise ThrottledError("Retry after 0.15 seconds")
+        if prompt == "invalid":
+            raise ValueError("Invalid prompt")
+        return None if prompt == "empty" else f"Reply to {prompt}"
+
+    engine = Aqute(
+        handle,
+        workers_count=3,
+        rate_limiter=limiter,
+        retry_count=2,
+        specific_errors_to_retry=ThrottledError,
+    )
+    async with request_pool(engine) as ask:
+        replies = await asyncio.gather(
+            *(ask(prompt) for prompt in ("first", "empty", "invalid", "retry")),
+            return_exceptions=True,
+        )
+        replies.append(await ask("later"))  # The same pool serves another caller.
+    return replies
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    replies = asyncio.run(main())
+    failures = sum(isinstance(reply, BaseException) for reply in replies)
+    logging.info("Results: %s replies, %s failure", len(replies) - failures, failures)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -26,6 +26,7 @@ nav:
   - Retry and progress: retry_progress.md
   - HTTP client: http_client.md
   - LLM inference: llm_inference.md
+  - Per-caller request pool: request_pool.md
   - Manual result draining: manual_drain.md
   - Service shutdown: service_shutdown.md
   - Development: development.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -33,6 +33,3 @@ markdown_extensions:
   - tables
   - pymdownx.highlight
   - pymdownx.superfences
-  - pymdownx.snippets:
-      base_path: ["."]
-      check_paths: true

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,6 +6,17 @@ edit_uri: edit/main/docs/
 theme:
   name: material
   font: false
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
   features:
     - content.action.edit
 nav:
@@ -14,6 +25,7 @@ nav:
   - Streaming: streaming.md
   - Retry and progress: retry_progress.md
   - HTTP client: http_client.md
+  - LLM inference: llm_inference.md
   - Manual result draining: manual_drain.md
   - Service shutdown: service_shutdown.md
   - Development: development.md

--- a/scripts/sync_examples.py
+++ b/scripts/sync_examples.py
@@ -15,7 +15,7 @@ BLOCK = re.compile(
 
 def sync_document(path: Path, *, check: bool) -> bool:
     """Return True when a check finds an outdated block; updates preserve prose."""
-    text = path.read_text()
+    text = path.read_text(encoding="utf-8")
     blocks = list(BLOCK.finditer(text))
     if text.count("<!-- example:") != len(blocks) or text.count(
         "<!-- /example -->"
@@ -24,7 +24,7 @@ def sync_document(path: Path, *, check: bool) -> bool:
 
     def render(match: re.Match[str]) -> str:
         source = match["source"]
-        code = (ROOT / source).read_text().rstrip("\n")
+        code = (ROOT / source).read_text(encoding="utf-8").rstrip("\n")
         return f"<!-- example: {source} -->\n```python\n{code}\n```\n<!-- /example -->"
 
     updated = BLOCK.sub(render, text)
@@ -33,7 +33,7 @@ def sync_document(path: Path, *, check: bool) -> bool:
     if check:
         logging.error("%s: examples differ; run make sync-examples", path)
         return True
-    path.write_text(updated)
+    path.write_text(updated, encoding="utf-8")
     logging.info("Updated %s", path)
     return False
 

--- a/scripts/sync_examples.py
+++ b/scripts/sync_examples.py
@@ -1,0 +1,58 @@
+"""Synchronize marked Markdown blocks with complete examples/*.py files."""
+
+import argparse
+import logging
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+BLOCK = re.compile(
+    r"^<!-- example: (?P<source>examples/[a-z_]+\.py) -->\n"
+    r".*?^<!-- /example -->$",
+    re.MULTILINE | re.DOTALL,
+)
+
+
+def sync_document(path: Path, *, check: bool) -> bool:
+    """Return True when a check finds an outdated block; updates preserve prose."""
+    text = path.read_text()
+    blocks = list(BLOCK.finditer(text))
+    if text.count("<!-- example:") != len(blocks) or text.count(
+        "<!-- /example -->"
+    ) != len(blocks):
+        raise ValueError(f"{path}: malformed example markers")
+
+    def render(match: re.Match[str]) -> str:
+        source = match["source"]
+        code = (ROOT / source).read_text().rstrip("\n")
+        return f"<!-- example: {source} -->\n```python\n{code}\n```\n<!-- /example -->"
+
+    updated = BLOCK.sub(render, text)
+    if updated == text:
+        return False
+    if check:
+        logging.error("%s: examples differ; run make sync-examples", path)
+        return True
+    path.write_text(updated)
+    logging.info("Updated %s", path)
+    return False
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--check", action="store_true", help="fail without writing")
+    args = parser.parse_args()
+    failed = False
+    try:
+        for path in [ROOT / "README.md", *sorted((ROOT / "docs").rglob("*.md"))]:
+            if sync_document(path, check=args.check):
+                failed = True
+    except (OSError, ValueError) as error:
+        logging.error("%s", error)
+        return 1
+    return int(failed)
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    raise SystemExit(main())

--- a/tests/examples/test_llm_inference.py
+++ b/tests/examples/test_llm_inference.py
@@ -1,0 +1,115 @@
+import asyncio
+import json
+from time import monotonic
+
+import httpx
+import pytest
+
+from aqute import Aqute, AquteTask
+from examples.llm_inference import Prompt, TokenCostLimiter, infer_batch
+
+
+@pytest.mark.asyncio
+async def test_inference_retries_429_and_resumes_from_checkpoint():
+    """Throttle once, save the output, and make no request for a saved input."""
+    prompt = Prompt("Classify: service is healthy", 10, 8)
+    checkpoint = {}
+    requests = []
+    arrivals = []
+
+    def respond(request):
+        requests.append(json.loads(request.content))
+        arrivals.append(monotonic())
+        if len(requests) == 1:
+            return httpx.Response(429, headers={"Retry-After": "1"})
+        return httpx.Response(
+            200,
+            json={
+                "choices": [{"message": {"content": "ok"}}],
+                "usage": {"total_tokens": 9},
+            },
+        )
+
+    assert (
+        await infer_batch([prompt], checkpoint, transport=httpx.MockTransport(respond))
+        == 1
+    )
+    assert checkpoint == {prompt: "ok"}
+    assert len(requests) == 2
+    assert (
+        requests[0]
+        == requests[1]
+        == {
+            "model": "your-model-name",
+            "messages": [{"role": "user", "content": prompt.text}],
+            "max_tokens": 8,
+        }
+    )
+    assert arrivals[1] - arrivals[0] >= 1
+
+    assert (
+        await infer_batch([prompt], checkpoint, transport=httpx.MockTransport(respond))
+        == 0
+    )
+    assert len(requests) == 2
+
+
+@pytest.mark.asyncio
+async def test_terminal_http_error_preserves_checkpoint_without_retry():
+    """A terminal failure remains unsaved and does not discard earlier output."""
+    completed = Prompt("Saved input", 10, 8)
+    failed = Prompt("Failing input", 10, 8)
+    checkpoint = {completed: "ok"}
+    calls = []
+
+    def respond(request):
+        calls.append(json.loads(request.content)["messages"][0]["content"])
+        return httpx.Response(503)
+
+    with pytest.raises(httpx.HTTPStatusError):
+        await infer_batch(
+            [completed, failed], checkpoint, transport=httpx.MockTransport(respond)
+        )
+    assert checkpoint == {completed: "ok"}
+    assert calls == [failed.text]
+
+
+@pytest.mark.asyncio
+async def test_token_cost_controls_admission():
+    """After spending the full budget, 25 more tokens require 0.25s of refill."""
+    limiter = TokenCostLimiter(6000, lambda prompt: prompt.estimated_input_tokens)
+    started = monotonic()
+    await limiter.acquire(task=AquteTask(Prompt("large", 6000, 0), "large"))
+    await limiter.acquire(task=AquteTask(Prompt("small", 25, 0), "small"))
+    assert monotonic() - started >= 0.25
+
+
+@pytest.mark.asyncio
+async def test_failed_attempt_keeps_its_token_reservation():
+    """A retry must wait for more budget even when the previous attempt failed."""
+    calls = []
+
+    async def fail(prompt):
+        calls.append(prompt)
+        raise ConnectionError("temporary failure")
+
+    prompt = Prompt("large", 5900, 100)
+    limiter = TokenCostLimiter(
+        6000, lambda prompt: prompt.estimated_input_tokens + prompt.max_tokens
+    )
+    engine = Aqute(fail, workers_count=1, rate_limiter=limiter, retry_count=1)
+    async with asyncio.timeout(2):
+        with pytest.raises(TimeoutError):
+            async with asyncio.timeout(0.1):
+                await engine.process_all([prompt])
+    assert calls == [prompt]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("cost", [0, -1, 61])
+async def test_invalid_cost_is_rejected_without_waiting(cost):
+    """An impossible reservation raises instead of waiting indefinitely."""
+    limiter = TokenCostLimiter(60, lambda prompt: prompt.estimated_input_tokens)
+    async with asyncio.timeout(1):
+        with pytest.raises(ValueError, match="cost"):
+            await limiter.acquire(task=AquteTask(Prompt("invalid", cost, 0), "bad"))

--- a/tests/examples/test_request_pool.py
+++ b/tests/examples/test_request_pool.py
@@ -1,0 +1,112 @@
+import asyncio
+
+import pytest
+
+from aqute import Aqute
+from examples.request_pool import request_pool
+
+
+@pytest.mark.asyncio
+async def test_routes_out_of_order_replies_none_and_errors():
+    """Each caller receives its own outcome even when another finishes first."""
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def handle(prompt: str) -> str | None:
+        if prompt == "slow":
+            started.set()
+            await release.wait()
+        if prompt == "invalid":
+            raise ValueError("Invalid prompt")
+        return None if prompt == "empty" else prompt.upper()
+
+    async with (
+        asyncio.timeout(1),
+        request_pool(Aqute(handle, 2)) as ask,
+        asyncio.TaskGroup() as callers,
+    ):
+        slow = callers.create_task(ask("slow"))
+        await started.wait()
+        assert await ask("fast") == "FAST"
+        assert not slow.done()
+        assert await ask("empty") is None
+        with pytest.raises(ValueError, match="Invalid prompt"):
+            await ask("invalid")
+        release.set()
+        assert await slow == "SLOW"
+        assert await ask("later") == "LATER"
+    with pytest.raises(RuntimeError, match="closed"):
+        await ask("too late")
+
+
+@pytest.mark.asyncio
+async def test_cancelled_caller_does_not_cancel_admitted_work_or_other_callers():
+    """Cancelling a waiter detaches its reply while the shared engine continues."""
+    started = asyncio.Event()
+    release = asyncio.Event()
+    finished = asyncio.Event()
+
+    async def handle(prompt: str) -> str:
+        if prompt == "cancelled":
+            started.set()
+            try:
+                await release.wait()
+            finally:
+                finished.set()
+        return prompt
+
+    async with asyncio.timeout(1), request_pool(Aqute(handle, 2)) as ask:
+        caller = asyncio.create_task(ask("cancelled"))
+        await started.wait()
+        caller.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await caller
+        assert not finished.is_set()
+        assert await ask("unaffected") == "unaffected"
+        release.set()
+    assert finished.is_set()
+
+
+@pytest.mark.asyncio
+async def test_owner_deadline_cleans_up_handler_and_pending_caller():
+    """A context deadline stops the worker and cancels the unresolved reply."""
+    baseline = asyncio.all_tasks()
+    started = asyncio.Event()
+    finished = asyncio.Event()
+
+    async def handle(prompt: str) -> str:
+        started.set()
+        try:
+            await asyncio.Event().wait()
+            return prompt
+        finally:
+            finished.set()
+
+    with pytest.raises(TimeoutError):
+        async with asyncio.timeout(0.1), request_pool(Aqute(handle, 1)) as ask:
+            caller = asyncio.create_task(ask("pending"))
+            await started.wait()
+            await asyncio.Event().wait()
+    with pytest.raises(asyncio.CancelledError):
+        await caller
+    assert finished.is_set()
+    assert not (asyncio.all_tasks() - baseline)
+
+
+@pytest.mark.asyncio
+async def test_normal_exit_delivers_an_admitted_reply():
+    """Normal shutdown drains the result before stopping its consumer."""
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def handle(prompt: str) -> str:
+        started.set()
+        await release.wait()
+        return prompt
+
+    async with asyncio.timeout(1):
+        async with request_pool(Aqute(handle, 1)) as ask:
+            caller = asyncio.create_task(ask("admitted"))
+            await started.wait()
+            release.set()
+        assert await caller == "admitted"

--- a/tests/examples/test_request_pool.py
+++ b/tests/examples/test_request_pool.py
@@ -110,3 +110,45 @@ async def test_normal_exit_delivers_an_admitted_reply():
             await started.wait()
             release.set()
         assert await caller == "admitted"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("defer_cancellation", [False, True])
+async def test_cancel_at_full_queue_release_keeps_later_replies_available(
+    defer_cancellation,
+):
+    """Cancelling a waiting caller must not strand subsequent callers' results."""
+    started = asyncio.Event()
+    release = asyncio.Event()
+    cancelled: asyncio.Task[str | None] | None = None
+
+    async def handle(prompt: str) -> str:
+        if prompt == "first":
+            started.set()
+            await release.wait()
+        if prompt == "queued":
+            assert cancelled is not None
+            if defer_cancellation:
+                asyncio.get_running_loop().call_soon(cancelled.cancel)
+            else:
+                cancelled.cancel()
+            await asyncio.sleep(0)
+        return prompt
+
+    async with (
+        asyncio.timeout(1),
+        request_pool(Aqute(handle, 1)) as ask,
+        asyncio.TaskGroup() as callers,
+    ):
+        first = callers.create_task(ask("first"))
+        await started.wait()
+        queued = callers.create_task(ask("queued"))
+        await asyncio.sleep(0)
+        cancelled = callers.create_task(ask("cancelled"))
+        await asyncio.sleep(0)
+        release.set()
+        assert await first == "first"
+        assert await queued == "queued"
+        with pytest.raises(asyncio.CancelledError):
+            await cancelled
+        assert await ask("later") == "later"

--- a/tests/examples/test_usage.py
+++ b/tests/examples/test_usage.py
@@ -18,6 +18,7 @@ from examples import http_client, retry_progress, service_shutdown, streaming
         ("retry_progress", "[0, 2, 4, 6, 8, 10, 12, 14]"),
         ("http_client", "2 pages"),
         ("llm_inference", "3 completions"),
+        ("request_pool", "4 replies, 1 failure"),
         ("manual_drain", str([(f"job-{value}", value * 2) for value in range(10)])),
     ],
 )

--- a/tests/examples/test_usage.py
+++ b/tests/examples/test_usage.py
@@ -17,6 +17,7 @@ from examples import http_client, retry_progress, service_shutdown, streaming
         ("streaming", "3 consumed"),
         ("retry_progress", "[0, 2, 4, 6, 8, 10, 12, 14]"),
         ("http_client", "2 pages"),
+        ("llm_inference", "3 completions"),
         ("manual_drain", str([(f"job-{value}", value * 2) for value in range(10)])),
     ],
 )

--- a/tests/test_sync_examples.py
+++ b/tests/test_sync_examples.py
@@ -1,0 +1,97 @@
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def checkout(tmp_path):
+    (tmp_path / "scripts").mkdir()
+    (tmp_path / "examples").mkdir()
+    (tmp_path / "docs").mkdir()
+    shutil.copyfile(
+        Path(__file__).resolve().parents[1] / "scripts/sync_examples.py",
+        tmp_path / "scripts/sync_examples.py",
+    )
+    return tmp_path
+
+
+def run_sync(checkout, *args):
+    return subprocess.run(
+        [sys.executable, str(checkout / "scripts/sync_examples.py"), *args],
+        cwd=checkout,
+        capture_output=True,
+        text=True,
+        timeout=5,
+        check=False,
+    )
+
+
+def test_sync_checks_and_updates_all_copies_without_changing_prose(checkout):
+    """CLI checks must detect drift without writing; sync updates every marked copy."""
+    source = checkout / "examples/demo.py"
+    source.write_text("run()\n")
+    block = (
+        "<!-- example: examples/demo.py -->\n"
+        "```python\nstale()\n```\n"
+        "<!-- /example -->\n"
+    )
+    documents = {
+        checkout / "README.md": "# Intro\n\n" + block + "\nSecond copy:\n" + block,
+        checkout / "docs/demo.md": block + "\nUnmarked:\n```python\nstale()\n```\n",
+    }
+    for path, text in documents.items():
+        path.write_text(text)
+
+    checked = run_sync(checkout, "--check")
+    assert checked.returncode == 1
+    assert "make sync-examples" in checked.stderr
+    assert {path: path.read_text() for path in documents} == documents
+
+    assert run_sync(checkout).returncode == 0
+    expected = {
+        path: text.replace(block, block.replace("stale()", "run()"))
+        for path, text in documents.items()
+    }
+    assert {path: path.read_text() for path in documents} == expected
+    assert run_sync(checkout, "--check").returncode == 0
+    assert run_sync(checkout).returncode == 0
+    assert {path: path.read_text() for path in documents} == expected
+
+    source.write_text("updated()\n")
+    assert run_sync(checkout, "--check").returncode == 1
+    assert {path: path.read_text() for path in documents} == expected
+
+
+@pytest.mark.parametrize("args", [(), ("--check",)])
+def test_missing_source_fails_without_replacing_the_copy(checkout, args):
+    """A removed or renamed source must fail the command with its path reported."""
+    readme = checkout / "README.md"
+    text = (
+        "<!-- example: examples/missing.py -->\n"
+        "```python\nkept()\n```\n<!-- /example -->\n"
+    )
+    readme.write_text(text)
+    result = run_sync(checkout, *args)
+    assert result.returncode == 1
+    assert "missing.py" in result.stderr
+    assert readme.read_text() == text
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "<!-- example: examples/demo.py -->\n```python\nrun()\n```\n",
+        "<!-- /example -->\n",
+    ],
+)
+def test_incomplete_markers_fail_instead_of_silently_skipping(checkout, text):
+    """Deleting one marker must not silently remove the example from CI checks."""
+    readme = checkout / "README.md"
+    readme.write_text(text)
+    result = run_sync(checkout, "--check")
+    assert result.returncode == 1
+    assert "malformed example markers" in result.stderr
+    assert readme.read_text() == text


### PR DESCRIPTION
Fix cancelled submissions to a full input queue leaving later completed results unpublished. Count queued work within the admission task so caller cancellation cannot skip that bookkeeping.

Add an offline LLM batch inference recipe showing token-cost admission, a shared pause after HTTP 429, explicit retry ownership, and application-owned checkpoints. Explain token estimates, the no-refund trade-off, initial bursts, and the limits of in-memory checkpoints.

Add a long-lived request-pool example that routes each terminal outcome to its caller by task ID. Show explicit startup, concurrent callers, selected retries, valid empty replies, caller cancellation, and shutdown. Clarify input backpressure, admission errors and shared-pause placement in the handler.

Embed full example sources in Markdown so readers can see the code on GitHub and the documentation site. HTML markers associate each copy with its source, and a synchronization command keeps the copies aligned.

Link the recipes from the introductory and usage pages, document synchronous I/O handlers with `asyncio.to_thread()` and executor limits, and compare broker-backed queues. Enable Material for MkDocs light/dark switching with the initial system preference and a saved manual selection.

The library API and dependencies are unchanged. The examples use simulated requests and do not provide durable delivery or a production service framework.
