### PR TITLE
docs: simplify navigation and align guidance with 0.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.10.1 - 2026-09-09
 
 - Fix cancelled submissions to a full input queue leaving later results
   unpublished. Admission and its task count now complete together, so cancelling
@@ -45,7 +45,7 @@ pre-submit-then-run with results drained after completion, set both
 only the result queue must be unlimited. Before processing starts, `add_task()`
 raises `AquteError` when the input queue is full. With finite result queues and no
 concurrent consumer, submission or completion can wait indefinitely. See
-[queue-default migration](https://insomnes.github.io/aqute/usage/#queue-default-migration).
+[manual buffering](https://insomnes.github.io/aqute/usage/#manual-buffering).
 
 `process_all()` still retains the complete result list. Helpers reject pending
 manual tasks and unconsumed results; finish manual work and drain results before

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ For a comparison with plain asyncio, aiometer, and broker-backed queues, see
 Aqute requires Python 3.11+. Install the version used by these examples:
 
 ```bash
-python -m pip install aqute==0.10.0
+python -m pip install aqute==0.10.1
 ```
 
 ## Quickstart
@@ -183,7 +183,7 @@ Install the optional HTTP client, then run this standalone example. It makes
 real GET requests; replace `urls` with your endpoints.
 
 ```bash
-python -m pip install aqute==0.10.0 httpx
+python -m pip install aqute==0.10.1 httpx
 ```
 
 Keep one client open around the managed result stream so workers finish cleanup
@@ -254,63 +254,28 @@ Both helpers accept `submission_batch_size` (default `1`). Larger batches can
 improve throughput for small tasks at the cost of result latency. Handlers still
 receive one item per call; configure worker concurrency and queue limits separately.
 
-## Bounded HTTP processing
-
-The [runnable HTTP example](https://insomnes.github.io/aqute/http_client/) combines
-a shared HTTPX client, four workers, an attempt-rate limiter, selected retries,
-and incremental result consumption. Its managed stream uses finite queue defaults
-and closes processing before the client. It logs each page and returns a count;
-queue limits bound items, not response bytes or data retained by your application.
-
-From a development checkout, run it without network access:
-
-```bash
-uv run --locked python -m examples.http_client
-```
-
-The example first compares throttling with and without a shared pause. It then
-completes a transport retry and handles a terminal HTTP error in a separate run.
-Its [source](https://github.com/insomnes/aqute/blob/main/examples/http_client.py)
-also provides an explicit path for real requests. The HTTP page includes the
-source and explains buffering overrides, retry safety, and its fail-fast policy.
-
 ## Documentation and examples
 
-The [documentation](https://insomnes.github.io/aqute/) includes the complete quickstart.
-[Usage](https://insomnes.github.io/aqute/usage/) covers bounded buffering, streaming cleanup, rate limits,
-retries, shutdown, counters, and migration from 0.9.2. The
-[changelog](https://github.com/insomnes/aqute/blob/main/CHANGELOG.md) collects the breaking changes and method renames. Full examples cover
-[streaming](https://insomnes.github.io/aqute/streaming/), [bounded HTTP processing](https://insomnes.github.io/aqute/http_client/),
-[manual result draining](https://insomnes.github.io/aqute/manual_drain/),
+The [usage guide](https://insomnes.github.io/aqute/usage/) explains buffering,
+errors, retries, shutdown, and counters. The
+[API reference](https://insomnes.github.io/aqute/reference/) lists constructor
+parameters and rate-limit options. See the
+[changelog](https://github.com/insomnes/aqute/blob/main/CHANGELOG.md) for migration
+from 0.9.x.
+
+Full recipes cover [streaming](https://insomnes.github.io/aqute/streaming/),
+[HTTP with shared Retry-After pauses](https://insomnes.github.io/aqute/http_client/),
+[LLM inference](https://insomnes.github.io/aqute/llm_inference/),
 [per-caller request pools](https://insomnes.github.io/aqute/request_pool/),
-and [service shutdown](https://insomnes.github.io/aqute/service_shutdown/).
-
-The [documentation source](https://github.com/insomnes/aqute/blob/main/docs/index.md)
-contains synchronized copies of the runnable examples, visible on GitHub and the
-documentation site. To build and view the site locally:
-
-```bash
-uv sync --locked
-make docs
-uv run --locked mkdocs serve
-```
+[manual result draining](https://insomnes.github.io/aqute/manual_drain/), and
+[service shutdown](https://insomnes.github.io/aqute/service_shutdown/).
+The request-pool recipe requires Aqute 0.10.1 or newer for cancellation safety.
+Examples are repository source to copy into your application; they are not
+installed with the package.
 
 ## Development
 
-Install [uv](https://docs.astral.sh/uv/getting-started/installation/), then run:
-
-```bash
-uv sync --locked
-make check
-make build
-uv run --locked python -m examples.quickstart
-```
-
-`make check` runs Ruff, ty, pytest with coverage, and the strict documentation build.
-See [development](https://insomnes.github.io/aqute/development/) for example commands and release behavior.
-CI tests Python 3.11 through 3.14. See [LICENSE](https://github.com/insomnes/aqute/blob/main/LICENSE).
-
-The measured coverage badge, XML, JSON, and HTML report are available in the
-`coverage-python-3.11` artifact of each successful [CI run](https://github.com/insomnes/aqute/actions/workflows/ci.yml).
-Run `make coverage` to generate the same files locally. See
-[coverage reporting](https://insomnes.github.io/aqute/development/#coverage) for the measurement scope.
+See [development](https://insomnes.github.io/aqute/development/) for checkout setup,
+example commands, checks, documentation builds, and
+[coverage reporting](https://insomnes.github.io/aqute/development/#coverage).
+See [LICENSE](https://github.com/insomnes/aqute/blob/main/LICENSE).

--- a/docs/http_client.md
+++ b/docs/http_client.md
@@ -4,8 +4,83 @@ Process independent GET requests with one shared HTTPX client and a fresh Aqute
 engine per run. The example combines four workers, an attempt-rate limiter,
 selected retries, and incremental result consumption.
 
-This recipe uses the 0.10.0 API for Python 3.11+. Follow the
+This recipe uses the 0.10.1 API for Python 3.11+. Follow the
 [installation instructions](index.md#installation).
+
+## Use in an application
+
+For real requests, call `await fetch_pages(urls)` without a transport. Install
+[Aqute](index.md#installation) and `httpx` in your
+application environment. HTTPX is a development dependency in this checkout;
+it is not an Aqute runtime dependency.
+
+The source imports `retry_delay` from the checkout's `examples.retry_progress`,
+which is not installed with `aqute`. To adapt it outside the checkout, copy the
+callback and its `from random import uniform` import from the
+[retry recipe](retry_progress.md), or provide your own callback. Replace the
+`examples.retry_progress` import with your application's import, or remove it if
+you define the callback in the same file.
+
+## Limits and outcomes
+
+In `fetch_pages()`, `workers_count=4` limits occupied workers. The inner
+`TokenBucketRateLimiter(max_rate=10)` spaces its grants by at least 0.1 seconds,
+including retries, with one initial grant available immediately.
+`PausableRateLimiter` adds a shared pause before and after the inner grant.
+Grants delayed by a pause can resume together; the wrapper does not reacquire
+permits or guarantee request spacing after that delay. Each client request uses
+HTTPX's five-second timeout setting.
+
+`retry_count=2` permits at most three attempts per URL. The recipe selects
+`httpx.TransportError` and HTTP 429, represented by `RateLimitedError`, for retries.
+Other HTTP status errors, including 503, are terminal. Transport errors use the
+[retry callback](retry_progress.md) for capped exponential backoff with jitter.
+
+On HTTP 429, `fetch_pages()` applies a shared pause from `Retry-After`. The retry
+callback also uses that header for the failed worker's retry delay. The parser
+accepts nonnegative numeric seconds or HTTP dates. Missing, malformed, negative,
+or nonfinite values use one second; past dates use zero. Valid delays have no
+upper bound. Apply any required cap in application code. See the
+[pause limits](reference.md#shared-pauses) for admission and timeout
+behavior. Applications must select retryable errors and operations for their
+own service.
+
+Aqute yields handler failures as terminal task error values. This example calls
+`task.unwrap()` to raise the first observed error and stop the run. Already logged
+pages remain logged; the remaining URLs might not complete. The offline entry
+point catches its expected HTTP error explicitly. Inspect `task.error` instead
+when your application must record failures and continue consuming results.
+
+The managed `iter_results()` context uses finite queues by default. With four
+workers, each input and result queue has capacity four. To choose other positive
+capacities, set `input_task_queue_size=I` and `result_queue=asyncio.Queue(R)` on
+the constructor. Zero means unlimited. See [buffering](usage.md#buffering) for
+the complete item bound and override rules.
+
+`fetch_pages()` logs each successful body as it arrives and returns only a count.
+It does not build a list of bodies. HTTPX still reads each complete response into
+memory. Queue capacities bound items, not bytes; source data, payload sizes, and
+data retained by application logging or persistence remain outside that bound.
+
+## Resource and retry ownership
+
+The stream context stops the producer and workers before the shared client closes,
+including when `unwrap()` or the input source raises. `fetch_pages()` owns its
+client and any supplied transport for that call. Aqute closes started generator
+sources; callers must explicitly close other source resources. See
+[streaming cleanup](usage.md#streaming-and-cleanup) for cancellation and early exit.
+
+The inputs are URL strings that can be reused for another attempt. To repeat a
+whole run, recreate an exhausted generator or use a replayable URL collection.
+Your application owns retry safety, duplicate side effects, and durable progress.
+Replace the log statement with application-owned parsing or persistence as needed;
+a logged response does not establish a durable checkpoint.
+
+See [Choose an API](index.md#choose-an-api) for a compact application-usage
+guide, and [manual processing](usage.md#manual-processing-and-shutdown) for
+externally managed producers and consumers.
+
+## Run the offline demonstration
 
 From a development checkout, run the example offline:
 
@@ -25,18 +100,6 @@ Next, it fetches two pages after one temporary connection failure. A separate ru
 returns HTTP 503, which the example reports as a terminal error. The entry point
 logs both page bodies and ends with `Results: 2 pages`. Each run uses a separate
 client and engine.
-
-For real requests, call `await fetch_pages(urls)` without a transport. Install
-[Aqute](index.md#installation) and `httpx` in your
-application environment. HTTPX is a development dependency in this checkout;
-it is not an Aqute runtime dependency.
-
-The source imports `retry_delay` from the checkout's `examples.retry_progress`,
-which is not installed with `aqute`. To adapt it outside the checkout, copy the
-callback and its `from random import uniform` import from the
-[retry recipe](retry_progress.md), or provide your own callback. Replace the
-`examples.retry_progress` import with your application's import, or remove it if
-you define the callback in the same file.
 
 ## Runnable source
 
@@ -230,62 +293,3 @@ if __name__ == "__main__":
     logging.info("Results: %s pages", asyncio.run(main()))
 ```
 <!-- /example -->
-
-## Limits and outcomes
-
-In `fetch_pages()`, `workers_count=4` limits occupied workers. The inner
-`TokenBucketRateLimiter(max_rate=10)` spaces its grants by at least 0.1 seconds,
-including retries, with one initial grant available immediately.
-`PausableRateLimiter` adds a shared pause before and after the inner grant.
-Grants delayed by a pause can resume together; the wrapper does not reacquire
-permits or guarantee request spacing after that delay. Each client request uses
-HTTPX's five-second timeout setting.
-
-`retry_count=2` permits at most three attempts per URL. The recipe selects
-`httpx.TransportError` and HTTP 429, represented by `RateLimitedError`, for retries.
-Other HTTP status errors, including 503, are terminal. Transport errors use the
-[retry callback](retry_progress.md) for capped exponential backoff with jitter.
-
-On HTTP 429, `fetch_pages()` applies a shared pause from `Retry-After`. The retry
-callback also uses that header for the failed worker's retry delay. The parser
-accepts nonnegative numeric seconds or HTTP dates. Missing, malformed, negative,
-or nonfinite values use one second; past dates use zero. Valid delays have no
-upper bound. Apply any required cap in application code. See the
-[pause limits](usage.md#concurrency-rate-and-priority) for admission and timeout
-behavior. Applications must select retryable errors and operations for their
-own service.
-
-Aqute yields handler failures as terminal task error values. This example calls
-`task.unwrap()` to raise the first observed error and stop the run. Already logged
-pages remain logged; the remaining URLs might not complete. The offline entry
-point catches its expected HTTP error explicitly. Inspect `task.error` instead
-when your application must record failures and continue consuming results.
-
-The managed `iter_results()` context uses finite queues by default. With four
-workers, each input and result queue has capacity four. To choose other positive
-capacities, set `input_task_queue_size=I` and `result_queue=asyncio.Queue(R)` on
-the constructor. Zero means unlimited. See [buffering](usage.md#buffering) for
-the complete item bound and override rules.
-
-`fetch_pages()` logs each successful body as it arrives and returns only a count.
-It does not build a list of bodies. HTTPX still reads each complete response into
-memory. Queue capacities bound items, not bytes; source data, payload sizes, and
-data retained by application logging or persistence remain outside that bound.
-
-## Resource and retry ownership
-
-The stream context stops the producer and workers before the shared client closes,
-including when `unwrap()` or the input source raises. `fetch_pages()` owns its
-client and any supplied transport for that call. Aqute closes started generator
-sources; callers must explicitly close other source resources. See
-[streaming cleanup](usage.md#streaming-and-cleanup) for cancellation and early exit.
-
-The inputs are URL strings that can be reused for another attempt. To repeat a
-whole run, recreate an exhausted generator or use a replayable URL collection.
-Your application owns retry safety, duplicate side effects, and durable progress.
-Replace the log statement with application-owned parsing or persistence as needed;
-a logged response does not establish a durable checkpoint.
-
-See [For coding agents](usage.md#for-coding-agents) for a compact application-usage
-guide, and [manual processing](usage.md#manual-processing-and-shutdown) for
-externally managed producers and consumers.

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,11 +17,23 @@ token-cost admission, shared throttling pauses, and checkpoints without a vendor
 
 ## Installation
 
-These pages and examples cover the 0.10.0 API. With Python 3.11+, install Aqute:
+These pages and examples cover the 0.10.1 API. With Python 3.11+, install Aqute:
 
 ```bash
-python -m pip install aqute==0.10.0
+python -m pip install aqute==0.10.1
 ```
+
+## Choose an API
+
+| Application need | Start here |
+| --- | --- |
+| A finite batch with an ordered result list | [`await engine.process_all(items)`](#1-collect-a-finite-batch-in-input-order) |
+| Incremental results in completion order | [`async with engine.iter_results(items) as results`](#3-consume-a-stream-and-stop-early) |
+| Continuous submission with separate producers and consumers | [Manual processing and shutdown](usage.md#manual-processing-and-shutdown) |
+| Independent callers awaiting their own replies from one engine | [Per-caller request pool](request_pool.md), using Aqute 0.10.1 or newer |
+
+Use a fresh engine for each helper run. Keep an external client open around the
+managed stream. For configuration defaults, see the [API reference](reference.md).
 
 ## Quickstart
 
@@ -182,7 +194,7 @@ Install the optional HTTP client, then run this standalone example. It makes
 real GET requests; replace `urls` with your endpoints.
 
 ```bash
-python -m pip install aqute==0.10.0 httpx
+python -m pip install aqute==0.10.1 httpx
 ```
 
 Keep one client open around the managed result stream so workers finish cleanup
@@ -264,27 +276,17 @@ uv run --locked python -m examples.streaming
 `uv run --locked python -m examples.quickstart_http` makes real network requests.
 The HTTP recipe below provides a separate offline example.
 
-## Bounded HTTP processing
+## Next steps
 
-Start with the [HTTP example](http_client.md) to combine four workers, a shared
-HTTPX client, attempt-rate limits, selected retries, and incremental results.
-The page includes the runnable source and explains its fail-fast error policy.
+The [HTTP recipe](http_client.md) adds shared `Retry-After` pauses and a fail-fast
+result policy. The [LLM recipe](llm_inference.md) adds estimated token budgets and
+application checkpoints. Both include offline demonstrations and instructions
+for adapting the source to real services.
 
-```bash
-uv run --locked python -m examples.http_client
-```
-
-This checkout command runs offline. It first compares throttling with and without
-a shared pause. It then completes a transport retry, logs two pages, and handles a
-terminal HTTP error in a separate run. Each run uses a fresh engine and a managed
-stream with finite queue defaults. `fetch_pages()` returns a count instead of
-retaining every body. Queues bound items, not payload bytes or application data.
-The same source provides an explicit callable path for real requests.
-
-For independent callers awaiting their own replies, see the
-[per-caller request pool](request_pool.md).
-See [For coding agents](usage.md#for-coding-agents) for helper selection and
-application ownership rules.
+See [Usage](usage.md) for error handling, buffering, cleanup, and manual processing.
+The [API reference](reference.md) lists parameters and rate-limit options.
+For upgrades from 0.9.x, use the
+[changelog and migration guide](https://github.com/insomnes/aqute/blob/main/CHANGELOG.md).
 
 ## When to choose Aqute
 
@@ -298,13 +300,3 @@ application ownership rules.
 For infrastructure changes, retries can repeat side effects; the application must
 decide which operations are safe to repeat. For remote inference, Aqute schedules
 handler attempts; model execution and provider-specific policy remain outside it.
-
-`process_all()`, `iter_results()`, and manual processing use finite input and result
-buffering by default, with each queue sized to `workers_count`. Manual runs must
-consume results concurrently or [choose unlimited queues explicitly](usage.md#queue-default-migration).
-Queue limits bound items, not bytes; `process_all()` retains the complete result
-list. See [buffering](usage.md#buffering) for overrides, the item bound, and migration.
-
-The `iter_results()` context awaits producer and worker cleanup, including after
-early exit. See [streaming and cleanup](usage.md#streaming-and-cleanup) for the
-lifecycle contract.

--- a/docs/llm_inference.md
+++ b/docs/llm_inference.md
@@ -5,6 +5,99 @@ bounded concurrency, selected retries, and incremental results. This example add
 a token-cost budget to the [HTTP recipe](http_client.md). It uses HTTPX directly;
 it does not require a vendor SDK, credentials, or a running model server.
 
+## Use in an application
+
+The checkout provides `httpx` in its development dependencies. To adapt the source
+outside the checkout, install `aqute==0.10.1` and `httpx`, and replace the endpoint,
+model, credentials, and token estimates with your application's configuration.
+The source imports `RateLimitedError` and `retry_after_seconds` from
+`examples.http_client`; copy those definitions from the [HTTP source](http_client.md#runnable-source)
+or supply equivalents. The `examples` package is not installed with Aqute.
+
+Call `await infer_batch(prompts, checkpoint)` after adapting the endpoint and
+request configuration. Each input is a `Prompt`; successful outputs are saved in
+the supplied dictionary. The first observed terminal error stops the batch.
+Keep checkpoint persistence and provider-specific policy in application code.
+
+## Requests and token budgets
+
+RPM counts requests per minute; TPM counts tokens per minute. Limiting request
+starts alone does not limit tokens when prompts and output lengths differ.
+`workers_count=3` limits occupied workers independently of either quota.
+This example controls estimated TPM; it does not add a separate RPM limiter.
+
+`TokenCostLimiter` implements the public `RateLimiter.acquire(name, task)`
+protocol in application code. Its cost callback reads `task.data` and reserves
+`estimated_input_tokens + max_tokens` before every attempt, including retries.
+The bucket starts full, refills continuously at 600 tokens per minute, and holds
+at most 600 tokens. One request's positive estimated cost must fit that capacity;
+an invalid cost raises `ValueError`. Through Aqute, it stops the run inside the
+worker `ExceptionGroup`; see [limiter failures](usage.md#errors-retries-and-timeouts).
+Initial bursts are possible: a full bucket can admit up to 1,200 estimated tokens
+in its first minute (600 initially plus 600 refilled). This token bucket does not
+enforce a strict rolling-minute ceiling.
+
+This is an **upper-bound estimate without refund**, conditional on the input
+estimate covering the actual input and `max_tokens` bounding the counted output.
+The supplied estimates are illustrative, not a tokenizer. Provider accounting
+differs by vendor and can include other token categories or reservation rules;
+the local limiter is a budget model, not a mirror of provider accounting.
+The response's `usage` is logged only. Failed attempts keep their reservation,
+and a successful response does not return unused tokens to the bucket.
+
+This conservative reservation underutilizes the budget when `max_tokens` greatly
+exceeds typical output length. Set `max_tokens` to the task's required output
+size, not an arbitrary safety margin. A refund based on reported usage could be
+an application extension for free-form generation, but is not implemented here.
+
+## Retries and throttling
+
+`PausableRateLimiter` wraps the token limiter. On HTTP 429, the handler parses
+`Retry-After`, extends the shared pause, and raises a retryable error.
+Already admitted requests can still complete or return 429. Admissions delayed
+by the pause can resume together; this wrapper does not guarantee spacing after
+the pause. Header parsing and fallback behavior follow the [HTTP recipe](http_client.md#limits-and-outcomes).
+
+`retry_count=2` allows at most three attempts per input. Only HTTP 429 and
+`httpx.TransportError` are retried, with a 0.1-second per-worker delay in addition
+to any remaining admission wait. Other HTTP errors propagate through
+`task.unwrap()`, stop the batch, and leave earlier checkpoints intact.
+The five-second HTTPX timeout applies to network operations, not the whole batch,
+token-budget waits, or shared pauses.
+
+There is no SDK retry layer in this example; the real HTTP transport explicitly
+uses `retries=0`, and the mock transport performs no automatic retries.
+If you replace HTTPX with an SDK, disable its internal retries (often
+`max_retries=0`) and let Aqute retry. Otherwise one handler attempt can make
+multiple requests after a single token reservation. Disable retries on one side
+to avoid multiplication: `retry_count=0` avoids Aqute retries, but SDK-internal
+attempts would still bypass this limiter. Disable SDK retries when the limiter
+must see every attempt. Select retries with your provider's billing and duplicate
+request behavior in mind; a transport failure does not prove inference never ran.
+
+## Checkpoints and cleanup
+
+After consuming a successful result, the application stores
+`checkpoint[task.data] = output`. A new batch filters those inputs out before
+submission. This demonstration keeps the checkpoint in memory, keyed by the full
+`Prompt` value. It is lost on process exit and assumes unique inputs for a fixed
+model and configuration. Duplicate inputs within one run can still be submitted.
+
+For resumable application work, persist the output and completion key together
+and include the model and relevant request configuration in that key. A crash
+after inference but before persistence can repeat a request; this example does
+not provide exactly-once execution or a durable queue. Application checkpoints
+also retain data outside Aqute's queue bounds. Each batch creates a fresh limiter,
+so restarting a batch resets the local budget and shared pause. Frequent short
+batches can therefore exceed the intended aggregate budget; share a limiter
+across batches in an application that needs continuous admission accounting.
+
+The managed result stream waits for producer and worker cleanup before the HTTP
+client closes. This requires cooperative cancellation. The example buffers each
+JSON response in memory; finite queues bound item counts, not response bytes.
+
+## Run the offline demonstration
+
 From a development checkout, run it offline:
 
 ```bash
@@ -188,87 +281,3 @@ if __name__ == "__main__":
     logging.info("Results: %s completions", asyncio.run(main()))
 ```
 <!-- /example -->
-
-The checkout provides `httpx` in its development dependencies. To adapt the source
-outside the checkout, install `aqute==0.10.0` and `httpx`, and replace the endpoint,
-model, credentials, and token estimates with your application's configuration.
-The source imports `RateLimitedError` and `retry_after_seconds` from
-`examples.http_client`; copy those definitions from the [HTTP source](http_client.md#runnable-source)
-or supply equivalents. The `examples` package is not installed with Aqute.
-
-## Requests and token budgets
-
-RPM counts requests per minute; TPM counts tokens per minute. Limiting request
-starts alone does not limit tokens when prompts and output lengths differ.
-`workers_count=3` limits occupied workers independently of either quota.
-This example controls estimated TPM; it does not add a separate RPM limiter.
-
-`TokenCostLimiter` implements the public `RateLimiter.acquire(name, task)`
-protocol in application code. Its cost callback reads `task.data` and reserves
-`estimated_input_tokens + max_tokens` before every attempt, including retries.
-The bucket starts full, refills continuously at 600 tokens per minute, and holds
-at most 600 tokens. One request's positive estimated cost must fit that capacity;
-an invalid cost raises `ValueError`. Through Aqute, it stops the run inside the
-worker `ExceptionGroup`; see [limiter failures](usage.md#errors-retries-and-timeouts).
-Initial bursts are possible: a full bucket can admit up to 1,200 estimated tokens
-in its first minute (600 initially plus 600 refilled). This token bucket does not
-enforce a strict rolling-minute ceiling.
-
-This is an **upper-bound estimate without refund**, conditional on the input
-estimate covering the actual input and `max_tokens` bounding the counted output.
-The supplied estimates are illustrative, not a tokenizer. Provider accounting
-differs by vendor and can include other token categories or reservation rules;
-the local limiter is a budget model, not a mirror of provider accounting.
-The response's `usage` is logged only. Failed attempts keep their reservation,
-and a successful response does not return unused tokens to the bucket.
-
-This conservative reservation underutilizes the budget when `max_tokens` greatly
-exceeds typical output length. Set `max_tokens` to the task's required output
-size, not an arbitrary safety margin. A refund based on reported usage could be
-an application extension for free-form generation, but is not implemented here.
-
-## Retries and throttling
-
-`PausableRateLimiter` wraps the token limiter. On HTTP 429, the handler parses
-`Retry-After`, extends the shared pause, and raises a retryable error.
-Already admitted requests can still complete or return 429. Admissions delayed
-by the pause can resume together; this wrapper does not guarantee spacing after
-the pause. Header parsing and fallback behavior follow the [HTTP recipe](http_client.md#limits-and-outcomes).
-
-`retry_count=2` allows at most three attempts per input. Only HTTP 429 and
-`httpx.TransportError` are retried, with a 0.1-second per-worker delay in addition
-to any remaining admission wait. Other HTTP errors propagate through
-`task.unwrap()`, stop the batch, and leave earlier checkpoints intact.
-The five-second HTTPX timeout applies to network operations, not the whole batch,
-token-budget waits, or shared pauses.
-
-There is no SDK retry layer in this example; the real HTTP transport explicitly
-uses `retries=0`, and the mock transport performs no automatic retries.
-If you replace HTTPX with an SDK, disable its internal retries (often
-`max_retries=0`) and let Aqute retry. Otherwise one handler attempt can make
-multiple requests after a single token reservation. Disable retries on one side
-to avoid multiplication: `retry_count=0` avoids Aqute retries, but SDK-internal
-attempts would still bypass this limiter. Disable SDK retries when the limiter
-must see every attempt. Select retries with your provider's billing and duplicate
-request behavior in mind; a transport failure does not prove inference never ran.
-
-## Checkpoints and cleanup
-
-After consuming a successful result, the application stores
-`checkpoint[task.data] = output`. A new batch filters those inputs out before
-submission. This demonstration keeps the checkpoint in memory, keyed by the full
-`Prompt` value. It is lost on process exit and assumes unique inputs for a fixed
-model and configuration. Duplicate inputs within one run can still be submitted.
-
-For resumable application work, persist the output and completion key together
-and include the model and relevant request configuration in that key. A crash
-after inference but before persistence can repeat a request; this example does
-not provide exactly-once execution or a durable queue. Application checkpoints
-also retain data outside Aqute's queue bounds. Each batch creates a fresh limiter,
-so restarting a batch resets the local budget and shared pause. Frequent short
-batches can therefore exceed the intended aggregate budget; share a limiter
-across batches in an application that needs continuous admission accounting.
-
-The managed result stream waits for producer and worker cleanup before the HTTP
-client closes. This requires cooperative cancellation. The example buffers each
-JSON response in memory; finite queues bound item counts, not response bytes.

--- a/docs/manual_drain.md
+++ b/docs/manual_drain.md
@@ -10,7 +10,7 @@ consumer runs during processing. The input queue keeps its default capacity of
 
 For bounded result buffering, consume `get_result()` concurrently instead; see
 [service shutdown](service_shutdown.md). To submit all inputs before starting,
-set `input_task_queue_size=0` as well. See [queue-default migration](usage.md#queue-default-migration).
+set `input_task_queue_size=0` as well. See [manual buffering](usage.md#manual-buffering).
 
 Lower priorities run first among pending tasks. They do not preempt active
 workers. The example sorts the returned values by task ID and runs offline.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1,0 +1,158 @@
+# API and rate limits
+
+This reference covers Aqute 0.10.1 for Python 3.11+. For runnable workflows, start
+with [Choose an API](index.md#choose-an-api) and the [usage guide](usage.md).
+Import the engine with `from aqute import Aqute`.
+
+## Constructor
+
+`Aqute(handle_coro, workers_count, ...)` takes two required arguments.
+All remaining parameters are keyword-only. `TData` and `TResult` are the handler's
+input and output types; public methods preserve these types.
+
+| Parameter | Type | Default | Meaning |
+| --- | --- | --- | --- |
+| `handle_coro` | `Callable[[TData], Coroutine[Any, Any, TResult]]` | Required | Async handler called with one input item per attempt. |
+| `workers_count` | `int` | Required | Maximum occupied workers, including rate-limit and retry waits. |
+| `rate_limiter` | `RateLimiter` or `None` | `None` | Attempt admission limiter; retries acquire it again. |
+| `result_queue` | `asyncio.Queue[AquteTask[TData, TResult]]` or `None` | `None` | Supplied result queue; its capacity also limits the internal result relay. Omission gives each capacity `workers_count`. |
+| `retry_count` | `int` | `0` | Extra attempts after the first handler call. |
+| `retry_delay` | `Callable[[int, Exception], float]` or `None` | `None` | Delay in seconds before a permitted retry; omission means zero delay. |
+| `specific_errors_to_retry` | Exception class, tuple of exception classes, or `None` | `None` | Eligible handler errors; `None` selects all caught handler errors while retry budget remains. |
+| `errors_to_not_retry` | Exception class, tuple of exception classes, or `None` | `None` | Excluded errors; takes precedence over the retry selection. |
+| `start_timeout_seconds` | `int`, `float`, or `None` | `None` | Limit on waiting for the first input after start; `None` disables the limit. |
+| `input_task_queue_size` | `int` or `None` | `None` | Pending input capacity; `None` means `workers_count`, zero means unlimited. |
+| `use_priority_queue` | `bool` | `False` | Order admitted pending tasks by increasing `task_priority`. |
+| `task_timeout_seconds` | `int`, `float`, or `None` | `None` | Timeout per handler attempt, excluding limiter and retry waits; `None` disables it. |
+| `total_failed_tasks_limit` | `int` or `None` | `None` | Stop when collected terminal failures reach this inclusive limit; `None` disables it. |
+
+Queue limits count items, not bytes or caller-retained data. See
+[buffering](usage.md#buffering) for the complete bound and
+[errors, retries, and timeouts](usage.md#errors-retries-and-timeouts) for failure behavior.
+
+## Helper options
+
+`process_all(items, *, submission_batch_size=1)` returns an awaited list in input
+order. `iter_results(items, *, submission_batch_size=1)` returns an async context
+for results in completion order. Both accept `Iterable[TData]` and
+`AsyncIterable[TData]`. `submission_batch_size` is a positive integer; larger
+batches can improve throughput for small tasks at the cost of result latency.
+Handlers still receive one item per call. See [streaming cleanup](usage.md#streaming-and-cleanup).
+
+## Rate limiters
+
+Available implementations are in `aqute.ratelimiter`:
+
+- `TokenBucketRateLimiter` controls a shared rate, with optional bursts.
+- `SlidingRateLimiter` limits calls within a moving time window.
+- `PerWorkerRateLimiter` applies a separate token bucket to each worker.
+- `RandomizedIntervalRateLimiter` adds bounded random delays after rolling-cap waits.
+- `PausableRateLimiter` wraps any limiter with a shared monotonic pause.
+
+For `TokenBucketRateLimiter` and `SlidingRateLimiter`, `max_rate` applies over
+`time_period` seconds; the default period is one second. To allow five grants
+in each rolling 0.2-second window:
+
+```python
+from aqute.ratelimiter import SlidingRateLimiter
+
+limiter = SlidingRateLimiter(max_rate=5, time_period=0.2)
+```
+
+The sliding limiter can grant all five permits together. A token bucket with
+`allow_burst=False` (the default) instead spaces grants by
+`time_period / max_rate` seconds.
+These limits apply to limiter grants; a pause wrapper can delay handler starts
+after a grant, as described below.
+
+### Shared pauses
+
+To pause attempt admission after service throttling, share one wrapper:
+
+```python
+from aqute.ratelimiter import PausableRateLimiter, TokenBucketRateLimiter
+
+limiter = PausableRateLimiter(TokenBucketRateLimiter(max_rate=10))
+engine = Aqute(handle, workers_count=4, rate_limiter=limiter)
+# Inside handle(), before raising a retryable throttle error:
+limiter.pause_for(2.0)
+```
+
+Call `pause_for()` in the handler before raising the retryable throttle error;
+the result consumer receives only terminal outcomes and cannot pause earlier retries.
+
+`pause_for(seconds)` extends the pause from `time.monotonic()` now.
+`pause_until(deadline)` takes an absolute deadline from that same clock.
+Both accept finite, nonnegative values and raise `ValueError` otherwise.
+The later deadline wins; a shorter pause cannot shorten the current one.
+Zero seconds and past deadlines add no wait. The read-only `paused_until`
+property starts at zero and retains the latest deadline after it expires.
+
+Use the wrapper on one event loop. Each `acquire()` checks the deadline in a loop
+before and after acquiring the inner limiter, including extensions set while
+either wait is active. Cancellation propagates. Requests already admitted are
+not interrupted. Inner grants delayed by a pause can resume together; the wrapper
+does not reacquire their permits or guarantee request spacing after that delay.
+
+The pause is outside `task_timeout_seconds`. A throttled attempt still consumes
+`retry_count`; select retryable errors and allow enough retries in the application.
+SDK-internal retries inside the handler multiply requests without acquiring the
+limiter again. The [HTTP recipe](http_client.md#limits-and-outcomes) parses
+`Retry-After` seconds or HTTP dates in application code and applies the shared
+pause. Missing or invalid headers use a one-second fallback; past dates use zero.
+The example applies no upper bound to valid `Retry-After` delays. Apply any
+required delay cap in application code.
+
+### Randomized intervals
+
+`RandomizedIntervalRateLimiter(N, T)` grants at most `N` acquisitions in each
+rolling `T` seconds. Each acquisition waits for quota, then for its full additional
+random delay. This delay also applies at startup, with sparse traffic and after
+idle. Quota waits and event-loop scheduling can increase the total wait beyond the
+configured jitter bounds. Sustained throughput can be below `N / T`.
+
+`mean_target_multiplier` and `std_dev` describe the Gaussian input, before scaling
+and bounding. They do not specify the mean or deviation of emitted intervals.
+An independent uniform phase supplies an absolute sine scale for each acquisition.
+The same scale multiplies the Gaussian input and `lower_upper_fluctuation`, which
+moves both multiplier bounds inward. The resulting bounded multiplier converts
+to seconds through `T / N`. Use nonnegative bounds and fluctuation, with
+`2 * lower_upper_fluctuation <= upper_multiplier_bound - lower_multiplier_bound`.
+The lower bound remains an additional minimum delay even when quota is available.
+
+Independent phases replace the previous request-counter ordering while retaining
+coupled amplitude and bound modulation. Seeded sequences and startup delays change.
+This reduces conspicuous counter-linked regularity; it does not model human
+behavior or guarantee avoidance of detection. Removing the old ordering can also
+reduce throughput, even when the overall delay distribution is similar.
+
+### Custom limiters
+
+A custom limiter implements `async acquire(name="", task=None)`. It must propagate
+cancellation. CPU-heavy or blocking work in a handler blocks the event loop;
+Aqute does not move it to threads or processes automatically.
+
+## Synchronous I/O handlers
+
+For a synchronous I/O handler, wrap the call in an async handler with
+`return await asyncio.to_thread(fn, item)`. The default executor caps its threads
+at `min(32, (cpu_count or 1) + 4)`: Python 3.11–3.12 uses `os.cpu_count()`, while
+Python 3.13+ uses `os.process_cpu_count()`. Effective concurrency can therefore be
+below `workers_count`. If needed, configure a custom `ThreadPoolExecutor(max_workers=...)`
+with `asyncio.get_running_loop().set_default_executor(executor)` before submitting
+work, and own its shutdown. See Python's [executor defaults](https://docs.python.org/3/library/concurrent.futures.html#concurrent.futures.ThreadPoolExecutor)
+and [`to_thread`](https://docs.python.org/3/library/asyncio-task.html#asyncio.to_thread).
+Cancellation or an Aqute timeout does not stop an already running thread; retries
+can overlap the original call, so use operation-level timeouts and safe retry
+policies. Threads generally do not make CPU-bound Python work parallel under the GIL.
+
+## Lower-level worker queues
+
+For lower-level worker queues,
+`aqute.worker.Foreman` exposes `start()`, `add_task(AquteTask(...))`,
+`get_handled_task()`, `finalize()`, and `stop()`. Consume finite result queues while
+waiting for `finalize()`.
+
+Inspect `error` and `result` on tasks returned directly by `Foreman`. It does not
+set `success`; `unwrap()` requires the engine's terminal success flag to return
+a value.

--- a/docs/request_pool.md
+++ b/docs/request_pool.md
@@ -11,8 +11,15 @@ Run the offline example from a development checkout:
 uv run --locked python -m examples.request_pool
 ```
 
-Use the checkout for this recipe: it fixes a bounded-submission cancellation bug
-that is still present in 0.10.0.
+Install Aqute 0.10.1 or newer before using this recipe in an application:
+
+```bash
+python -m pip install aqute==0.10.1
+```
+
+The released package includes the bounded-submission cancellation fix missing
+from 0.10.0. Copy the source below into your application; the `examples` package
+is not installed with Aqute. A library checkout is not required.
 
 The simulated handler sleeps for 25–100 ms. It returns a valid `None` for
 `empty`, raises a terminal `ValueError` for `invalid`, and throttles `retry` once.

--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -2,7 +2,7 @@
 
 Use streaming to process results as they complete. Start with a fresh engine and
 consume each terminal task inside the managed context. For an ordered finite batch
-or continuous manual submission, see the [API selector](usage.md#for-coding-agents).
+or continuous manual submission, see the [API selector](index.md#choose-an-api).
 
 From a development checkout, run this finite example offline:
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,7 +1,12 @@
 # Usage
 
-This page covers the 0.10.0 API for Python 3.11+. Follow the
-[installation instructions](index.md#installation).
+<span id="for-coding-agents"></span>
+
+This guide covers the 0.10.1 API for Python 3.11+. Start with
+[installation](index.md#installation) and [Choose an API](index.md#choose-an-api).
+See the [API reference](reference.md) for parameter types and defaults, or the
+[changelog](https://github.com/insomnes/aqute/blob/main/CHANGELOG.md) for migration
+from 0.9.x.
 
 ## Task results
 
@@ -44,6 +49,7 @@ Aqute closes started generator sources. Callers own other source resources,
 including custom iterators with `close()` or `aclose()` methods.
 
 Use each context and iterator once, and consume results inside the context.
+For one result at a time, call `await anext(results)` on the yielded iterator.
 Use the engine sequentially. Before reusing it with a helper after partial
 consumption, retrieve all retained results. Both helpers raise `AquteError` when
 results remain in the result queue, including a caller-supplied queue. Rejection
@@ -59,7 +65,11 @@ new_results = await engine.process_all(new_items)
 The new helper run returns only its own results. Use a fresh engine when old
 results must remain in their original queue. Helpers require a fresh or stopped
 engine with no pending manual tasks. Conflicting setup raises `AquteError` before
-consuming input. Use the manual API for externally managed producers and consumers.
+consuming input. Preloading with `add_task()` before either helper is rejected.
+Use the manual API to finish such work while draining results, then stop the
+engine before using a helper. Use a fresh engine for each helper run when reuse
+is unnecessary. Helpers accept synchronous and asynchronous inputs; recreate an
+exhausted generator before repeating a run.
 
 ## Buffering
 
@@ -86,157 +96,32 @@ source or caller and the growing list returned by `process_all()`. A queue size 
 zero is unlimited. Multiple independent producer calls can each hold an item
 while waiting for admission; the formula above assumes one producer.
 
-### Queue-default migration
-
-This is a pre-1.0 behavior break for manual runs. Omitted limits now use capacity
-`workers_count`, just like helper runs. Existing positive capacities and explicit
-zero limits keep their meaning. Manual runs using the defaults must consume
-results concurrently with submission and processing.
-
-To preserve pre-submit-then-run or other unlimited buffering, set both limits
-explicitly:
-
-```python
-engine = Aqute(
-    handle,
-    workers_count=32,
-    input_task_queue_size=0,
-    result_queue=asyncio.Queue(0),
-)
-```
-
-Pre-submit-then-run needs both queues unlimited when all inputs are submitted
-before starting and results are drained after completion. A full input queue
-before `start()` now raises `AquteError` from `add_task()` instead of waiting
-indefinitely. Start processing first or opt into unlimited input explicitly.
-
-Run-then-drain starts processing before submission and needs only
-`result_queue=asyncio.Queue(0)`; the input queue can keep its default capacity.
-See the [manual drain example](manual_drain.md). With finite result queues and no
-concurrent consumer, `add_task()` or `finish()` can wait indefinitely. Aqute does
-not detect this arrangement.
-
-Helpers now reject pending manual tasks, so preloading with `add_task()` before
-`process_all()` or `iter_results()` raises `AquteError`. Follow
-[manual processing and shutdown](#manual-processing-and-shutdown) to finish the
-work while draining results, then stop the engine before using a helper.
-Alternatively, use a separate fresh engine for the helper.
+For manual flows without a concurrent result consumer, see
+[manual buffering](#manual-buffering). The
+[changelog](https://github.com/insomnes/aqute/blob/main/CHANGELOG.md) describes
+migration from the older unlimited defaults.
 
 ## Concurrency, rate, and priority
 
-`workers_count` limits occupied workers. It does not specify requests per second.
-Use `rate_limiter` to control attempt rate. Every retry acquires the limiter again.
-Available implementations are in `aqute.ratelimiter`:
+`workers_count` limits occupied workers; it does not specify requests per second.
+Set `rate_limiter` to control attempt admission. Every retry acquires it again.
+A waiting attempt occupies its worker, including rate-limit and retry-delay waits.
+CPU-heavy or blocking handlers block the event loop. For synchronous I/O, see
+[thread offloading and its limits](reference.md#synchronous-io-handlers).
 
-- `TokenBucketRateLimiter` controls a shared rate, with optional bursts.
-- `SlidingRateLimiter` limits calls within a moving time window.
-- `PerWorkerRateLimiter` applies a separate token bucket to each worker.
-- `RandomizedIntervalRateLimiter` adds bounded random delays after rolling-cap waits.
-- `PausableRateLimiter` wraps any limiter with a shared monotonic pause.
+Use `TokenBucketRateLimiter(max_rate=N)` to space grants by at least `1 / N`
+seconds, with one initial grant available immediately. To pause all workers after
+throttling, wrap a limiter in `PausableRateLimiter` and call `pause_for()` inside
+the handler before raising a retryable error. Pauses delay admission, leave
+already admitted requests running, and can cause delayed grants to resume together.
+See [rate limiters](reference.md#rate-limiters) for imports, periods, bursts,
+shared pauses, and custom limiters.
 
-For `TokenBucketRateLimiter` and `SlidingRateLimiter`, `max_rate` applies over
-`time_period` seconds; the default period is one second. To allow five grants
-in each rolling 0.2-second window:
-
-```python
-from aqute.ratelimiter import SlidingRateLimiter
-
-limiter = SlidingRateLimiter(max_rate=5, time_period=0.2)
-```
-
-The sliding limiter can grant all five permits together. A token bucket with
-`allow_burst=False` (the default) instead spaces grants by
-`time_period / max_rate` seconds.
-These limits apply to limiter grants; a pause wrapper can delay handler starts
-after a grant, as described below.
-
-To pause attempt admission after service throttling, share one wrapper:
-
-```python
-from aqute.ratelimiter import PausableRateLimiter, TokenBucketRateLimiter
-
-limiter = PausableRateLimiter(TokenBucketRateLimiter(max_rate=10))
-engine = Aqute(handle, workers_count=4, rate_limiter=limiter)
-# Inside handle(), before raising a retryable throttle error:
-limiter.pause_for(2.0)
-```
-
-Call `pause_for()` in the handler before raising the retryable throttle error;
-the result consumer receives only terminal outcomes and cannot pause earlier retries.
-
-`pause_for(seconds)` extends the pause from `time.monotonic()` now.
-`pause_until(deadline)` takes an absolute deadline from that same clock.
-Both accept finite, nonnegative values and raise `ValueError` otherwise.
-The later deadline wins; a shorter pause cannot shorten the current one.
-Zero seconds and past deadlines add no wait. The read-only `paused_until`
-property starts at zero and retains the latest deadline after it expires.
-
-Use the wrapper on one event loop. Each `acquire()` checks the deadline in a loop
-before and after acquiring the inner limiter, including extensions set while
-either wait is active. Cancellation propagates. Requests already admitted are
-not interrupted. Inner grants delayed by a pause can resume together; the wrapper
-does not reacquire their permits or guarantee request spacing after that delay.
-
-The pause is outside `task_timeout_seconds`. A throttled attempt still consumes
-`retry_count`; select retryable errors and allow enough retries in the application.
-SDK-internal retries inside the handler multiply requests without acquiring the
-limiter again. The [HTTP example source](http_client.md#runnable-source) parses
-`Retry-After` seconds or HTTP dates in application code and applies the shared
-pause. Missing or invalid headers use a one-second fallback; past dates use zero.
-The example applies no upper bound to valid `Retry-After` delays. Apply any
-required delay cap in application code.
-
-Its offline entry point also compares eight workers processing forty URLs during
-one 300 ms throttle window, with `Retry-After: 1` and a 100-attempt/second limiter.
-The transport returns each response immediately, before the next admission.
-It logs throttled-request counts, retries, and elapsed time with and without the
-shared pause. Real requests already in flight can still return 429 after a pause;
-this controlled comparison is not a bound on their count or a throughput claim.
-
-`RandomizedIntervalRateLimiter(N, T)` grants at most `N` acquisitions in each
-rolling `T` seconds. Each acquisition waits for quota, then for its full additional
-random delay. This delay also applies at startup, with sparse traffic and after
-idle. Quota waits and event-loop scheduling can increase the total wait beyond the
-configured jitter bounds. Sustained throughput can be below `N / T`.
-
-`mean_target_multiplier` and `std_dev` describe the Gaussian input, before scaling
-and bounding. They do not specify the mean or deviation of emitted intervals.
-An independent uniform phase supplies an absolute sine scale for each acquisition.
-The same scale multiplies the Gaussian input and `lower_upper_fluctuation`, which
-moves both multiplier bounds inward. The resulting bounded multiplier converts
-to seconds through `T / N`. Use nonnegative bounds and fluctuation, with
-`2 * lower_upper_fluctuation <= upper_multiplier_bound - lower_multiplier_bound`.
-The lower bound remains an additional minimum delay even when quota is available.
-
-Independent phases replace the previous request-counter ordering while retaining
-coupled amplitude and bound modulation. Seeded sequences and startup delays change.
-This reduces conspicuous counter-linked regularity; it does not model human
-behavior or guarantee avoidance of detection. Removing the old ordering can also
-reduce throughput, even when the overall delay distribution is similar.
-
-A custom limiter implements `async acquire(name="", task=None)`. It must propagate
-cancellation. CPU-heavy or blocking work in a handler blocks the event loop;
-Aqute does not move it to threads or processes automatically.
-
-For a synchronous I/O handler, wrap the call in an async handler with
-`return await asyncio.to_thread(fn, item)`. The default executor caps its threads
-at `min(32, (cpu_count or 1) + 4)`: Python 3.11–3.12 uses `os.cpu_count()`, while
-Python 3.13+ uses `os.process_cpu_count()`. Effective concurrency can therefore be
-below `workers_count`. If needed, configure a custom `ThreadPoolExecutor(max_workers=...)`
-with `asyncio.get_running_loop().set_default_executor(executor)` before submitting
-work, and own its shutdown. See Python's [executor defaults](https://docs.python.org/3/library/concurrent.futures.html#concurrent.futures.ThreadPoolExecutor)
-and [`to_thread`](https://docs.python.org/3/library/asyncio-task.html#asyncio.to_thread).
-Cancellation or an Aqute timeout does not stop an already running thread; retries
-can overlap the original call, so use operation-level timeouts and safe retry
-policies. Threads generally do not make CPU-bound Python work parallel under the GIL.
-
-With `use_priority_queue=True`, pass `task_priority` to `add_task()`. Lower values
-run first among admitted pending tasks. Priority does not preempt an occupied
-worker. A worker retains its task through retries.
-Only tasks currently in the input queue can be reordered. A positive
-`input_task_queue_size` bounds this set; the default capacity is `workers_count`.
-Increasing capacity lets more pending tasks compete by priority but retains more
-inputs. Priority does not order callers still waiting for admission.
+With `use_priority_queue=True`, lower `task_priority` values run first among
+pending tasks already in the input queue. Priority does not order callers still
+waiting for admission or preempt occupied workers. A worker retains its task
+through retries. Increasing input capacity lets more tasks compete by priority
+but retains more inputs.
 
 ## Errors, retries, and timeouts
 
@@ -297,12 +182,7 @@ logging.getLogger("aqute.worker").setLevel(logging.ERROR)
 This also suppresses warnings for terminal handler failures. It does not change
 retries or result delivery.
 
-The [HTTP example](http_client.md) uses one shared HTTPX client and retries
-transport errors and HTTP 429 responses. Other HTTP status failures propagate
-to its caller. Its executable
-entry point uses an offline transport; applications call `fetch_pages(urls)` for
-real requests. HTTPX is required only for this example and is included in the dev
-group. See [HTTPX's async client guide](https://www.python-httpx.org/async/).
+The [HTTP recipe](http_client.md) applies these rules to transport errors and HTTP 429.
 
 ## Manual processing and shutdown
 
@@ -341,7 +221,7 @@ call. These methods do not reject later submissions while the run still has work
 `await run()` starts processing and finishes work submitted before start.
 With finite result queues, keep the consumer running while awaiting completion.
 For pre-submit-then-run, explicitly set both queues unlimited. For run-then-drain,
-set only the result queue unlimited; see [queue-default migration](#queue-default-migration)
+set only the result queue unlimited; see [manual buffering](#manual-buffering)
 and the [manual drain example](manual_drain.md). After `run()` or `finish()`
 completes, await `stop()` before starting a helper.
 
@@ -362,14 +242,34 @@ manager or a `finally` block.
 
 Completed results remain available after `stop()`. After `await stop()`, call
 `start()` again to reuse the same engine; `stop()` resets the run task and counters.
-Drain retained results before using a helper again. For lower-level worker queues,
-`aqute.worker.Foreman` exposes `start()`, `add_task(AquteTask(...))`,
-`get_handled_task()`, `finalize()`, and `stop()`. Consume finite result queues while
-waiting for `finalize()`.
+Drain retained results before using a helper again.
 
-Inspect `error` and `result` on tasks returned directly by `Foreman`. It does not
-set `success`; `unwrap()` requires the engine's terminal success flag to return
-a value.
+<span id="queue-default-migration"></span>
+
+### Manual buffering
+
+With the default finite queues, keep a result consumer running while submitting
+and awaiting `finish()`. Without it, `add_task()` or `finish()` can wait indefinitely;
+Aqute does not detect this arrangement.
+
+For run-then-drain, start the engine before submission and set
+`result_queue=asyncio.Queue(0)`. The input queue can keep its default capacity.
+Results accumulate in memory until drained; see the [manual drain recipe](manual_drain.md).
+
+To submit every input before starting and drain results after completion, make
+both queues unlimited:
+
+```python
+engine = Aqute(
+    handle,
+    workers_count=32,
+    input_task_queue_size=0,
+    result_queue=asyncio.Queue(0),
+)
+```
+
+A full input queue before `start()` raises `AquteError`; start processing first or
+choose unlimited input explicitly. Stop producers before signalling completion.
 
 ## Progress counters
 
@@ -392,68 +292,3 @@ Helpers stop on exit. Inspect their counters during iteration, or use the manual
 flow to inspect them after `finish()` and before `stop()`. The
 [retry](retry_progress.md) and [service](service_shutdown.md) examples log these
 snapshots.
-
-## Migration from 0.9.2
-
-The old method names are removed without compatibility wrappers. Update calls
-when upgrading from 0.9.2:
-
-| 0.9.2 call | Replacement |
-| --- | --- |
-| `engine.set_all_tasks_added()` | `engine.finish_submitting()` |
-| `await engine.wait_till_end()` | `await engine.finish()` |
-| `await engine.start_and_wait()` | `await engine.run()` |
-| `await engine.get_task_result()` | `await engine.get_result()` |
-| `engine.extract_all_results()` | `engine.drain_results()` |
-| `await engine.apply_to_all(items)` | `await engine.process_all(items)` |
-| `engine.apply_to_each(items)` | `async with engine.iter_results(items) as results` |
-
-For streaming, iterate `results` inside the async context shown in
-[streaming and cleanup](#streaming-and-cleanup). The context awaits cleanup on
-exit, including after an early `break`. Call `anext(results)` on the yielded
-iterator; do not call `aclose()` on the context.
-
-`start()`, `stop()`, and `add_task()` keep their names. Generic handler input and
-result types are preserved through the public methods and the async context
-manager. For example, a handler accepting `int` makes `add_task("text")` a type
-error; this is an intentionally invalid call, not a runnable usage example.
-
-The upgrade also requires Python 3.11 or newer and uses finite buffering by
-default for helper and manual runs. See [buffering](#buffering) for explicit unlimited settings and the
-[changelog](https://github.com/insomnes/aqute/blob/main/CHANGELOG.md) for the
-breaking changes together. The
-[0.9.x maintenance branch](https://github.com/insomnes/aqute/tree/maintenance/0.9.x)
-retains the old API for Python 3.9 and 3.10.
-
-## For coding agents
-
-For application code, [install Aqute](index.md#installation)
-with Python 3.11+ and import `Aqute` from `aqute`. The
-[canonical HTTP recipe](http_client.md) also requires `httpx`; the checkout's dev
-group includes it. For independent callers sharing a long-lived engine, start
-with the [per-caller request pool](request_pool.md). Choose the example matching
-the application's input and result flow instead of reconstructing the API.
-
-| Application need | API |
-| --- | --- |
-| A finite batch with an ordered result list | `await engine.process_all(items)` |
-| Results in completion order, with bounded buffering and incremental consumption | `async with engine.iter_results(items) as results`, then iterate `results` inside the context |
-| Continuous submission with separate producer and consumer ownership | Follow [manual processing and shutdown](#manual-processing-and-shutdown) |
-| Independent callers each waiting for their own reply from a shared engine | Use the [per-caller request pool](request_pool.md) example |
-
-- Create a fresh engine for each helper run. The stream context waits for cleanup
-  after completion, early exit, or failure. Keep the external client open around
-  that context. Aqute closes started generator sources; callers own other source
-  resources and must close them explicitly.
-- Leave queue limits omitted for finite defaults in all APIs, with each queue
-  sized to `workers_count`. Use positive capacities to override them; zero is unlimited.
-  These are item limits. Payload bytes, caller-retained data, and the complete
-  list returned by `process_all()` are outside the bound. See [buffering](#buffering).
-- Handle each terminal task explicitly. `task.unwrap()` returns the successful
-  value, including a valid `None`, or raises its error. Inspect `task.error` or
-  `task.success` when collecting partial failures. A false or `None` result does
-  not prove failure. See [task results](#task-results).
-- Select safe retry errors and a finite retry count. Every retry acquires the
-  attempt-rate limiter again; worker count controls concurrency separately.
-  Keep inputs replayable. Applications own repeated side effects, client policy,
-  and durable progress. See [retry rules](#errors-retries-and-timeouts).

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -50,6 +50,7 @@ including custom iterators with `close()` or `aclose()` methods.
 
 Use each context and iterator once, and consume results inside the context.
 For one result at a time, call `await anext(results)` on the yielded iterator.
+Do not call `aclose()` on the context; leave the `async with` block instead.
 Use the engine sequentially. Before reusing it with a helper after partial
 consumption, retrieve all retained results. Both helpers raise `AquteError` when
 results remain in the result queue, including a caller-supplied queue. Rejection

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -20,15 +20,20 @@ theme:
   features:
     - content.action.edit
 nav:
-  - Quickstart: index.md
-  - Usage: usage.md
-  - Streaming: streaming.md
-  - Retry and progress: retry_progress.md
-  - HTTP client: http_client.md
-  - LLM inference: llm_inference.md
-  - Per-caller request pool: request_pool.md
-  - Manual result draining: manual_drain.md
-  - Service shutdown: service_shutdown.md
+  - Getting started:
+      - Quickstart: index.md
+      - Usage guide: usage.md
+  - Reference:
+      - API and rate limits: reference.md
+      - Changelog and migration: https://github.com/insomnes/aqute/blob/main/CHANGELOG.md
+  - Recipes:
+      - Streaming: streaming.md
+      - Retry and progress: retry_progress.md
+      - HTTP client: http_client.md
+      - LLM inference: llm_inference.md
+      - Per-caller request pool: request_pool.md
+      - Manual result draining: manual_drain.md
+      - Service shutdown: service_shutdown.md
   - Development: development.md
 markdown_extensions:
   - tables


### PR DESCRIPTION
Move API selection before the quickstart and collect constructor defaults and advanced limiter details in one reference. Keep all four README examples and complete Markdown source blocks, shorten repeated entry-page material, and explain HTTP/LLM integration before the offline demonstrations.

Align installation and request-pool guidance with Aqute 0.10.1. The recipe now requires the released cancellation fix instead of an unreleased library checkout, and the changelog assigns the fix to 0.10.1. Preserve the distinction between the installed library and example source copied into an application.
