### PR TITLE
fix: keep generated task IDs unique under backpressure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Keep generated task IDs distinct during concurrent submissions waiting for input
+  capacity. Cancelled submissions can leave gaps in the per-run sequence.
+
 ## 0.10.1 - 2026-09-09
 
 - Fix cancelled submissions to a full input queue leaving later results

--- a/aqute/engine.py
+++ b/aqute/engine.py
@@ -117,6 +117,7 @@ class Aqute(Generic[TData, TResult]):
             retry_delay=retry_delay,
         )
 
+        self._next_task_id = 0
         self._added_tasks_count = 0
         self._finished_tasks_count = 0
 
@@ -220,7 +221,8 @@ class Aqute(Generic[TData, TResult]):
         Args:
             task_data: Data for the task to process.
             task_id (optional): Identifier for the task. If not provided, it's
-                auto-generated based on the added tasks count.
+                generated from a per-run sequence before waiting for input capacity.
+                Cancelled submissions can leave gaps in this sequence.
             task_priority (optional): Priority of the task used if priority queue is
                 enabled. Lower means more prior task. Defaults to 1_000_000.
 
@@ -232,7 +234,7 @@ class Aqute(Generic[TData, TResult]):
                 or set input_task_queue_size=0 for unlimited pre-submission.
                 Also raised when the load has completed or was cancelled.
         """
-        task_id = task_id or str(self._added_tasks_count)
+        task_id = task_id or str(self._next_task_id)
 
         task: AquteTask[TData, TResult] = AquteTask(
             data=task_data,
@@ -251,6 +253,8 @@ class Aqute(Generic[TData, TResult]):
                 "Input queue is full before start(); call start() first "
                 "or set input_task_queue_size=0 for unlimited pre-submission"
             )
+        # Reserve before admission can suspend; admitted-task accounting stays separate.
+        self._next_task_id += 1
         if load is None or not self._foreman.in_queue.full():
             await self._foreman.add_task(task)
             self._added_tasks_count += 1
@@ -535,6 +539,7 @@ class Aqute(Generic[TData, TResult]):
                 await self._foreman.stop()
             finally:
                 self.aiotask_of_run_load = None
+                self._next_task_id = 0
                 self._added_tasks_count = 0
                 self._finished_tasks_count = 0
                 self._failed_tasks = 0

--- a/aqute/engine.py
+++ b/aqute/engine.py
@@ -214,20 +214,21 @@ class Aqute(Generic[TData, TResult]):
         """
         Asynchronously adds a new task for processing.
 
-        Generates a unique task_id if one isn't provided. The task is then
-        forwarded to the foreman for execution and the count of added tasks is
-        incremented.
+        Within one run, omitted or empty IDs receive distinct generated values.
+        Caller-supplied IDs are not checked for collisions. The task is forwarded
+        to the foreman for execution and the count of added tasks is incremented.
 
         Args:
             task_data: Data for the task to process.
-            task_id (optional): Identifier for the task. If not provided, it's
+            task_id (optional): Identifier for the task. If omitted or empty, it's
                 generated from a per-run sequence before waiting for input capacity.
                 Cancelled submissions can leave gaps in this sequence.
+                stop() resets the sequence, so later runs can reuse generated IDs.
             task_priority (optional): Priority of the task used if priority queue is
                 enabled. Lower means more prior task. Defaults to 1_000_000.
 
         Returns:
-            The unique task_id associated with the added task.
+            The task_id associated with the added task.
 
         Raises:
             AquteError: If the input queue is full before start(). Start processing

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -196,7 +196,8 @@ do not `await engine.start()` before submitting input. The
 Start workers before filling a bounded input queue; otherwise `add_task()` raises
 `AquteError` when the input queue is already full. With default limits, submit with
 `await add_task(data)` and consume results concurrently with `await get_result()`.
-Custom IDs use `task_id`; omitted IDs are generated. `drain_results()` removes currently available results without waiting.
+Custom IDs use `task_id`; omitted IDs are generated.
+`drain_results()` removes currently available results without waiting.
 `get_result()` raises `AquteError` after normal completion when no results remain.
 While the run is active and the result queue is empty, `get_result()` waits for
 a result or run completion, with no timeout of its own.
@@ -204,6 +205,12 @@ After start, a full input queue makes `add_task()` wait for capacity;
 it raises `AquteError` if the run completes normally before admission.
 Default capacity `workers_count` can therefore block service callers
 inside submission, so bound concurrent callers or apply an admission timeout.
+
+**Unreleased:** Concurrent `add_task()` calls with omitted or empty IDs receive
+distinct generated IDs within one run, including while waiting for input capacity.
+Cancelled submissions can leave gaps. `stop()` resets the sequence, so later runs
+can reuse generated IDs. Caller-supplied IDs are not checked for duplicates or
+collisions with generated IDs.
 
 Results use one shared queue. `get_result()` returns the next available result,
 not necessarily the result of the caller's last `add_task()`. For per-caller

--- a/tests/test_generated_task_ids.py
+++ b/tests/test_generated_task_ids.py
@@ -1,0 +1,79 @@
+import asyncio
+
+import pytest
+
+from aqute import Aqute
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("cancel_blocked", [False, True])
+@pytest.mark.parametrize("use_priority_queue", [False, True])
+async def test_concurrent_generated_ids_match_completed_inputs(
+    cancel_blocked: bool, use_priority_queue: bool
+):
+    """Blocked submissions keep distinct result IDs, including after cancellation."""
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def handle(value: int) -> int:
+        started.set()
+        await release.wait()
+        return value * 2
+
+    engine = Aqute(
+        handle,
+        1,
+        input_task_queue_size=1,
+        result_queue=asyncio.Queue(0),
+        use_priority_queue=use_priority_queue,
+    )
+
+    async def submit(value: int, submitting: asyncio.Event) -> str:
+        submitting.set()
+        return await engine.add_task(value)
+
+    # The deadline detects a stranded result or completion, not elapsed performance.
+    async with asyncio.timeout(5), engine, asyncio.TaskGroup() as group:
+        try:
+            ids = {0: await engine.add_task(0)}
+            await started.wait()
+            ids[1] = await engine.add_task(1)
+            assert engine.counters.pending == 1
+
+            blocked = {}
+            for value in (2, 3):
+                submitting = asyncio.Event()
+                blocked[value] = group.create_task(submit(value, submitting))
+                await submitting.wait()
+                assert not blocked[value].done()
+
+            if cancel_blocked:
+                cancelled = blocked.pop(2)
+                cancelled.cancel()
+                with pytest.raises(asyncio.CancelledError):
+                    await cancelled
+                submitting = asyncio.Event()
+                blocked[4] = group.create_task(submit(4, submitting))
+                await submitting.wait()
+                assert not blocked[4].done()
+
+            release.set()
+            for value, submission in blocked.items():
+                ids[value] = await submission
+            ids[5] = await engine.add_task(5)
+            ids[6] = await engine.add_task(6, task_id="caller-id")
+            assert ids[6] == "caller-id"
+            first_result = await engine.get_result()
+            await engine.finish()
+            results = [first_result, *engine.drain_results()]
+
+            assert len(set(ids.values())) == len(ids)
+            assert sorted(
+                (task.data, task.task_id, task.unwrap()) for task in results
+            ) == [(value, task_id, value * 2) for value, task_id in sorted(ids.items())]
+        finally:
+            release.set()
+
+    # A completed manual run must leave ordered helpers usable on the same engine.
+    results = await engine.process_all([8, 6, 7])
+    assert [task.unwrap() for task in results] == [16, 12, 14]


### PR DESCRIPTION
Concurrent submissions could receive the same generated task ID while waiting for input capacity. Reserve IDs before admission waits, while preserving admitted-task accounting and result routing.

Generated IDs are distinct within one run. Cancelled submissions can leave gaps, and caller-supplied IDs remain unchecked.
