### PR TITLE
fix: preserve handler timeouts for retry filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 - Keep generated task IDs distinct during concurrent submissions waiting for input
   capacity. Cancelled submissions can leave gaps in the per-run sequence.
+- Preserve handler-raised `TimeoutError` when the Aqute deadline has not expired,
+  including with no deadline. Previously, Aqute converted it to
+  `AquteTaskTimeoutError`; retry filters now match the original exception.
+  Use `TimeoutError` for handler timeouts and `AquteTaskTimeoutError` for Aqute
+  deadlines, or include both types to select or exclude both kinds of timeout.
 
 ## 0.10.1 - 2026-09-09
 

--- a/aqute/worker.py
+++ b/aqute/worker.py
@@ -119,16 +119,10 @@ class Worker(Generic[TData, TResult]):
                 and timeout.expired()
             ):
                 exc = AquteTaskTimeoutError(f"Task {task.task_id} timed out")
-            if isinstance(exc, AquteTaskTimeoutError):
-                logger.warning(
-                    f"Worker {self.name} on {task.task_id} timed out after "
-                    f"{self.task_timeout_seconds} seconds"
-                )
-            else:
-                logger.warning(
-                    f"Worker {self.name} on {task.task_id} got error: "
-                    f"{exc.__class__}: {exc}"
-                )
+            logger.warning(
+                f"Worker {self.name} on {task.task_id} got error: "
+                f"{exc.__class__}: {exc}"
+            )
             task.error = exc
 
 

--- a/aqute/worker.py
+++ b/aqute/worker.py
@@ -99,29 +99,36 @@ class Worker(Generic[TData, TResult]):
     ) -> None:
         if self.rate_limiter:
             await self.rate_limiter.acquire(name=self.name, task=task)
+        timeout: asyncio.Timeout | None = None
         try:
             if self.task_timeout_seconds is not None and self.task_timeout_seconds <= 0:
-                raise TimeoutError
+                raise AquteTaskTimeoutError(f"Task {task.task_id} timed out")
             if self.task_timeout_seconds is None:
                 if is_retry:
                     self._counters.retries += 1
                 task.result = await self.handle_coro(task.data)
             else:
-                async with asyncio.timeout(self.task_timeout_seconds):
+                async with asyncio.timeout(self.task_timeout_seconds) as timeout:
                     if is_retry:
                         self._counters.retries += 1
                     task.result = await self.handle_coro(task.data)
-        except TimeoutError:
-            logger.warning(
-                f"Worker {self.name} on {task.task_id} timed out after "
-                f"{self.task_timeout_seconds} seconds"
-            )
-            task.error = AquteTaskTimeoutError(f"Task {task.task_id} timed out")
         except Exception as exc:
-            logger.warning(
-                f"Worker {self.name} on {task.task_id} got error: "
-                f"{exc.__class__}: {exc}"
-            )
+            if (
+                isinstance(exc, TimeoutError)
+                and timeout is not None
+                and timeout.expired()
+            ):
+                exc = AquteTaskTimeoutError(f"Task {task.task_id} timed out")
+            if isinstance(exc, AquteTaskTimeoutError):
+                logger.warning(
+                    f"Worker {self.name} on {task.task_id} timed out after "
+                    f"{self.task_timeout_seconds} seconds"
+                )
+            else:
+                logger.warning(
+                    f"Worker {self.name} on {task.task_id} got error: "
+                    f"{exc.__class__}: {exc}"
+                )
             task.error = exc
 
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -148,6 +148,13 @@ repeat a side effect, so applications must decide whether retrying is safe.
 negative timeout prevents handler invocation. Add `AquteTaskTimeoutError` to
 `errors_to_not_retry` when timeouts must not be retried.
 
+**Unreleased:** A handler-raised `TimeoutError` retains its original type and
+message when the Aqute deadline has not expired, including when
+`task_timeout_seconds=None`. Retry filters now match that original exception.
+Previously, Aqute converted it to `AquteTaskTimeoutError`. Use `TimeoutError` in
+the filters for handler timeouts and `AquteTaskTimeoutError` for Aqute deadlines.
+Include both types to select or exclude both kinds of timeout.
+
 Import the public exception types directly from `aqute`:
 
 ```python

--- a/tests/test_handler_timeout_retry.py
+++ b/tests/test_handler_timeout_retry.py
@@ -1,0 +1,102 @@
+import asyncio
+
+import pytest
+
+from aqute import Aqute, AquteTaskTimeoutError
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("task_timeout", [None, 60])
+async def test_handler_timeout_retries_when_selected(task_timeout):
+    """A selected handler TimeoutError gets one retry and returns success."""
+    calls = 0
+
+    async def handler(value: int) -> int:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise TimeoutError("upstream timed out")
+        return value
+
+    engine = Aqute(
+        handler,
+        1,
+        task_timeout_seconds=task_timeout,
+        retry_count=1,
+        specific_errors_to_retry=TimeoutError,
+    )
+    (result,) = await engine.process_all([7])
+
+    assert calls == 2
+    assert result.unwrap() == 7
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("task_timeout", [None, 60])
+async def test_handler_timeout_exclusion_preserves_original_error(task_timeout):
+    """An excluded TimeoutError is delivered unchanged without another attempt."""
+    calls = 0
+    error = TimeoutError("upstream timed out")
+
+    async def handler(value: int) -> int:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise error
+        return value
+
+    engine = Aqute(
+        handler,
+        1,
+        task_timeout_seconds=task_timeout,
+        retry_count=1,
+        errors_to_not_retry=TimeoutError,
+    )
+    (result,) = await engine.process_all([7])
+
+    assert calls == 1
+    assert result.error is error
+    with pytest.raises(TimeoutError, match=r"^upstream timed out$") as caught:
+        result.unwrap()
+    assert caught.value is error
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("retry_error", "excluded_error", "expected_calls"),
+    [
+        (AquteTaskTimeoutError, None, 2),
+        (AquteTaskTimeoutError, AquteTaskTimeoutError, 1),
+        (TimeoutError, None, 1),
+    ],
+)
+async def test_aqute_deadline_respects_its_retry_filters(
+    retry_error, excluded_error, expected_calls
+):
+    """A real handler deadline uses AquteTaskTimeoutError for retry decisions."""
+    calls = 0
+
+    async def handler(value: int) -> int:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            await asyncio.Event().wait()
+        return value
+
+    engine = Aqute(
+        handler,
+        1,
+        task_timeout_seconds=0.01,
+        retry_count=1,
+        specific_errors_to_retry=retry_error,
+        errors_to_not_retry=excluded_error,
+    )
+    async with asyncio.timeout(1):
+        (result,) = await engine.process_all([7])
+
+    assert calls == expected_calls
+    if expected_calls == 2:
+        assert result.unwrap() == 7
+    else:
+        with pytest.raises(AquteTaskTimeoutError, match="timed out"):
+            result.unwrap()


### PR DESCRIPTION
Preserve a handler-raised `TimeoutError` when Aqute’s deadline has not expired. Retry selection and exclusion now use the original exception, and terminal results preserve its type and message.

`AquteTaskTimeoutError` continues to represent Aqute deadline expiry and nonpositive timeout limits. Callers can include both exception types when one policy must cover both timeout sources.
