### PR TITLE
fix: terminate runs after unexpected worker cancellation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@
   `AquteTaskTimeoutError`; retry filters now match the original exception.
   Use `TimeoutError` for handler timeouts and `AquteTaskTimeoutError` for Aqute
   deadlines, or include both types to select or exclude both kinds of timeout.
+- Fail the run with an `ExceptionGroup` containing `AquteError` when an awaited
+  operation propagates `asyncio.CancelledError` without a cancellation request
+  on the worker, instead of leaving the run waiting indefinitely. The cancelled
+  work is not retried and produces no terminal task result. Sibling workers are
+  cancelled and awaited for cooperative cleanup; stop and caller cancellation
+  retain their existing behavior.
 
 ## 0.10.1 - 2026-09-09
 

--- a/aqute/worker.py
+++ b/aqute/worker.py
@@ -6,7 +6,7 @@ from collections.abc import Callable, Coroutine
 from dataclasses import dataclass
 from typing import Any, Generic
 
-from aqute.errors import AquteTaskTimeoutError
+from aqute.errors import AquteError, AquteTaskTimeoutError
 from aqute.ratelimiter import RateLimiter
 from aqute.task import END_MARKER, AquteTask, AquteTaskQueueType, TData, TResult
 
@@ -60,6 +60,16 @@ class Worker(Generic[TData, TResult]):
                 if task.data is END_MARKER:
                     return
                 await self.handle_task(task)
+            except asyncio.CancelledError as exc:
+                worker = asyncio.current_task()
+                assert worker is not None
+                if worker.cancelling():
+                    raise
+                # TaskGroup ignores child cancellation. Fail the run when an
+                # awaited operation cancels without a request to stop this worker.
+                raise AquteError(
+                    f"Worker {self.name} on task {task.task_id} cancelled unexpectedly"
+                ) from exc
             finally:
                 self._counters.running -= 1
                 self.input_q.task_done()

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -41,7 +41,8 @@ same context internally and returns a list in input order.
 
 Context exit waits for the producer and workers to stop after full consumption,
 an early `break`, a consumer exception, a source exception, or cancellation.
-Source and consumer errors propagate; handler errors remain task error values.
+Source and consumer errors propagate; handler exceptions derived from `Exception`
+remain task error values.
 Caller cancellation, including a deadline during cleanup, propagates through the
 existing cooperative cleanup path. Cleanup requires sources, handlers, and rate
 limiters to cooperate with cancellation; it cannot forcibly terminate them.
@@ -126,8 +127,9 @@ but retains more inputs.
 
 ## Errors, retries, and timeouts
 
-Handler exceptions become `AquteTask.error` values. `retry_count` specifies extra
-attempts; its default is zero. `specific_errors_to_retry` selects exception types.
+Handler exceptions derived from `Exception` become `AquteTask.error` values.
+`retry_count` specifies extra attempts; its default is zero.
+`specific_errors_to_retry` selects exception types.
 When omitted, it defaults to `None`: every caught handler error is eligible while
 the retry budget remains.
 `errors_to_not_retry` excludes types and takes precedence when both filters match.
@@ -142,6 +144,14 @@ continue. Cancellation interrupts the delay. Invalid delays raise `ValueError`
 inside the worker `ExceptionGroup`. Callback errors and limiter failures also stop
 the worker group and propagate; they are not handler error values. A retry can
 repeat a side effect, so applications must decide whether retrying is safe.
+
+**Unreleased:** If an awaited operation propagates `asyncio.CancelledError`
+without a cancellation request on the worker, the run fails with an
+`ExceptionGroup` containing `AquteError`. For example, this occurs when a handler
+awaits an independently cancelled `asyncio.Future`. The cancelled work is not
+retried and produces no terminal task result. Aqute cancels sibling workers and
+waits for their cooperative cleanup. Cancellation requested through `stop()` or
+by the caller keeps its existing behavior.
 
 `task_timeout_seconds` limits each handler attempt and produces
 `AquteTaskTimeoutError`. Rate-limit and retry-delay waits are excluded. A zero or

--- a/tests/test_worker_cancellation.py
+++ b/tests/test_worker_cancellation.py
@@ -1,0 +1,119 @@
+import asyncio
+import contextlib
+
+import pytest
+
+from aqute import Aqute, AquteError
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("workers_count", [1, 2])
+@pytest.mark.parametrize("task_timeout_seconds", [None, 10])
+async def test_cancelled_handler_operation_terminates_process_all(
+    workers_count, task_timeout_seconds
+):
+    """A cancelled dependency fails the run without retries and cleans siblings."""
+    tasks_before = asyncio.all_tasks()
+    sibling_started = asyncio.Event()
+    calls = []
+    cleaned = []
+
+    async def handler(value: int) -> int:
+        calls.append(value)
+        try:
+            if value == 1:
+                if workers_count > 1:
+                    await sibling_started.wait()
+                dependency = asyncio.get_running_loop().create_future()
+                dependency.cancel()
+                await dependency
+            else:
+                sibling_started.set()
+                await asyncio.Event().wait()
+            return value
+        finally:
+            await asyncio.sleep(0)
+            cleaned.append(value)
+
+    engine = Aqute(
+        handler,
+        workers_count,
+        retry_count=2,
+        task_timeout_seconds=task_timeout_seconds,
+    )
+    operation = asyncio.create_task(engine.process_all([1, 2]))
+    try:
+        # Cancelling a stalled operation can expose errors only during cleanup.
+        # Establish completion before cancellation can hide the original hang.
+        done, _ = await asyncio.wait((operation,), timeout=1)
+        assert operation in done
+        with pytest.raises(ExceptionGroup) as caught:
+            await operation
+        assert len(caught.value.exceptions) == 1
+        error = caught.value.exceptions[0]
+        assert isinstance(error, AquteError)
+        assert "cancelled unexpectedly" in str(error)
+        assert isinstance(error.__cause__, asyncio.CancelledError)
+        assert calls.count(1) == 1
+        assert sorted(cleaned) == sorted(calls)
+        if workers_count > 1:
+            assert 2 in cleaned
+        assert engine.drain_results() == []
+        assert asyncio.all_tasks() == tasks_before
+    finally:
+        operation.cancel()
+        with contextlib.suppress(asyncio.CancelledError, ExceptionGroup):
+            await operation
+        await engine.stop()
+
+
+@pytest.mark.asyncio
+async def test_cancelled_handler_operation_fails_manual_reader_and_finish():
+    """Both manual completion boundaries fail after owned handler cleanup."""
+    tasks_before = asyncio.all_tasks()
+    sibling_started = asyncio.Event()
+    release = asyncio.Event()
+    cleaned = []
+
+    async def handler(value: int) -> int:
+        try:
+            if value == 1:
+                await sibling_started.wait()
+                await release.wait()
+                dependency = asyncio.get_running_loop().create_future()
+                dependency.cancel()
+                await dependency
+            else:
+                sibling_started.set()
+                await asyncio.Event().wait()
+            return value
+        finally:
+            await asyncio.sleep(0)
+            cleaned.append(value)
+
+    engine = Aqute(handler, 2)
+    load = engine.start()
+    await engine.add_task(1)
+    await engine.add_task(2)
+    reader = asyncio.create_task(engine.get_result())
+    finishing = asyncio.create_task(engine.finish())
+    try:
+        release.set()
+        done, _ = await asyncio.wait((reader, finishing, load), timeout=1)
+        assert done == {reader, finishing, load}
+        for operation in (reader, finishing, load):
+            with pytest.raises(ExceptionGroup) as caught:
+                await operation
+            assert len(caught.value.exceptions) == 1
+            assert isinstance(caught.value.exceptions[0], AquteError)
+            assert "cancelled unexpectedly" in str(caught.value.exceptions[0])
+        assert sorted(cleaned) == [1, 2]
+        assert engine.drain_results() == []
+        assert asyncio.all_tasks() == tasks_before
+    finally:
+        for operation in (reader, finishing, load):
+            operation.cancel()
+            with contextlib.suppress(asyncio.CancelledError, ExceptionGroup):
+                await operation
+        with contextlib.suppress(ExceptionGroup):
+            await engine.stop()


### PR DESCRIPTION
A handler awaiting an independently cancelled operation could silently remove a worker and leave the run waiting forever. Propagate this failure through the existing worker supervision, with an `ExceptionGroup` containing `AquteError`, and wait for sibling cleanup.

The cancelled work is not retried and produces no terminal task result. Explicit shutdown and caller cancellation retain their existing cooperative behavior.
