### PR TITLE
fix: correct cancellation, startup timeout and retry edge cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,14 @@
 # Changelog
 
-## Unreleased
+## 0.10.3 - 2026-09-09
 
 - Raise `AquteError` from `finish()` and `iter_results()` when processing is
   independently cancelled. Preserve caller cancellation and cleanup deadlines.
 - Process prequeued inputs with zero or negative `start_timeout_seconds`;
   the timeout applies only while waiting for the first input.
 - Treat `specific_errors_to_retry=()` as selecting no retryable errors.
+- Remove the unused, importable `aqute.task.END_MARKER` sentinel and its worker
+  shutdown path.
 - Clarify that cancellation of `Aqute.add_task()` or `Foreman.add_task()` can
   race completed admission and does not prove that the task was not accepted.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+- Raise `AquteError` from `finish()` and `iter_results()` when processing is
+  independently cancelled. Preserve caller cancellation and cleanup deadlines.
+- Process prequeued inputs with zero or negative `start_timeout_seconds`;
+  the timeout applies only while waiting for the first input.
+- Treat `specific_errors_to_retry=()` as selecting no retryable errors.
+- Clarify that cancellation of `Aqute.add_task()` or `Foreman.add_task()` can
+  race completed admission and does not prove that the task was not accepted.
+
+## 0.10.2 - 2026-09-09
+
 - Keep generated task IDs distinct during concurrent submissions waiting for input
   capacity. Cancelled submissions can leave gaps in the per-run sequence.
 - Preserve handler-raised `TimeoutError` when the Aqute deadline has not expired,

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ For a comparison with plain asyncio, aiometer, and broker-backed queues, see
 Aqute requires Python 3.11+. Install the version used by these examples:
 
 ```bash
-python -m pip install aqute==0.10.1
+python -m pip install aqute==0.10.3
 ```
 
 ## Quickstart
@@ -183,7 +183,7 @@ Install the optional HTTP client, then run this standalone example. It makes
 real GET requests; replace `urls` with your endpoints.
 
 ```bash
-python -m pip install aqute==0.10.1 httpx
+python -m pip install aqute==0.10.3 httpx
 ```
 
 Keep one client open around the managed result stream so workers finish cleanup

--- a/aqute/engine.py
+++ b/aqute/engine.py
@@ -66,12 +66,13 @@ class Aqute(Generic[TData, TResult]):
                 exception to finite, nonnegative seconds. Defaults to zero delay.
                 The delay occupies a worker but is outside the handler timeout.
             specific_errors_to_retry (optional): Exceptions triggering
-                task retry. Defaults to None, so every error is retried.
+                task retry. None selects every error; an empty tuple selects none.
             errors_to_not_retry (optional): Exceptions that should not be
                 retried. This option takes precedence over specific_errors_to_retry.
                 Defaults to None.
             start_timeout_seconds (optional): Wait time before failing after start
-                if no tasks were added. Defaults to None.
+                if no tasks were added. Prequeued tasks do not wait, even when
+                this value is zero or negative. Defaults to None.
             input_task_queue_size (optional): Maximum pending input items.
                 None (the default) uses workers_count for all runs. Positive
                 values set an explicit capacity; 0 is unlimited. Start processing
@@ -181,7 +182,8 @@ class Aqute(Generic[TData, TResult]):
         task is active, this method waits until it completes.
 
         Raises:
-            AquteError: If the task hasn't been initiated.
+            AquteError: If the task has not been initiated or its load was
+                independently cancelled. Caller cancellation still propagates.
             AquteTooManyTasksFailedError: If there was limit on failed tasks
                 and it was reached.
 
@@ -192,7 +194,15 @@ class Aqute(Generic[TData, TResult]):
         if self.aiotask_of_run_load is None:
             raise AquteError("Cannot wait for not started load")
         self.finish_submitting()
-        await self.aiotask_of_run_load
+        caller = asyncio.current_task()
+        assert caller is not None
+        cancelling = caller.cancelling()
+        try:
+            await self.aiotask_of_run_load
+        except asyncio.CancelledError as exc:
+            if caller.cancelling() > cancelling:
+                raise
+            raise AquteError("Load was cancelled; call stop first") from exc
         logger.debug("Aqute load task ended")
 
     async def run(self) -> None:
@@ -217,6 +227,9 @@ class Aqute(Generic[TData, TResult]):
         Within one run, omitted or empty IDs receive distinct generated values.
         Caller-supplied IDs are not checked for collisions. The task is forwarded
         to the foreman for execution and the count of added tasks is incremented.
+        Cancellation can race completed admission: a cancelled submission does
+        not prove that the task was not accepted. Admission accounting includes
+        accepted work, even when the submitting caller is cancelled.
 
         Args:
             task_data: Data for the task to process.
@@ -308,6 +321,9 @@ class Aqute(Generic[TData, TResult]):
         """
         Return a context that owns a single-use, lazy result iterator.
 
+        Do not call get_result() or drain_results() during iteration: the iterator
+        owns result consumption.
+
         Produce input concurrently with processing and yield terminal results
         in completion order. Finite input and result queues bound buffering.
         Use ``async with engine.iter_results(items) as results``. First iteration
@@ -316,6 +332,8 @@ class Aqute(Generic[TData, TResult]):
         consumer exception, or cancellation. Cleanup requires cooperative sources
         and handlers. Drain retained results before reusing the engine.
         Source exceptions propagate after cancelling owned processing.
+        Independently cancelled processing raises AquteError. Cancellation of
+        the consuming caller still propagates, including during cleanup.
 
         Omitted queue limits use workers_count items for pending input, results,
         and the internal result relay. With finite input capacity I, result
@@ -349,7 +367,7 @@ class Aqute(Generic[TData, TResult]):
             self._iter_results(tasks_data, submission_batch_size=submission_batch_size)
         )
 
-    async def _iter_results(
+    async def _iter_results(  # noqa: C901 - keep load cancellation checks local
         self,
         tasks_data: Iterable[TData] | AsyncIterable[TData],
         *,
@@ -376,11 +394,21 @@ class Aqute(Generic[TData, TResult]):
                             yield self.result_queue.get_nowait()
                             continue
                         if load.done():
+                            if load.cancelled():
+                                raise AquteError("Load was cancelled; call stop first")
                             await load
                         changed.clear()
                         await changed.wait()
                     await producer
-                    await load
+                    caller = asyncio.current_task()
+                    assert caller is not None
+                    cancelling = caller.cancelling()
+                    try:
+                        await load
+                    except asyncio.CancelledError as exc:
+                        if caller.cancelling() > cancelling:
+                            raise
+                        raise AquteError("Load was cancelled; call stop first") from exc
                 finally:
                     producer.cancel()
                     caller = asyncio.current_task()
@@ -574,8 +602,6 @@ class Aqute(Generic[TData, TResult]):
             return
 
         try:
-            if self._start_timeout_seconds <= 0:
-                raise TimeoutError
             async with asyncio.timeout(self._start_timeout_seconds):
                 while (
                     self._added_tasks_count == self._finished_tasks_count
@@ -627,7 +653,7 @@ class Aqute(Generic[TData, TResult]):
         ):
             return False
 
-        if self._specific_errors_to_retry and not isinstance(
+        if self._specific_errors_to_retry is not None and not isinstance(
             task.error, self._specific_errors_to_retry
         ):
             return False

--- a/aqute/task.py
+++ b/aqute/task.py
@@ -4,9 +4,6 @@ from typing import Generic, NamedTuple, TypeVar, cast
 
 from aqute.errors import AquteError
 
-END_MARKER = object()
-
-
 TData = TypeVar("TData")
 TResult = TypeVar("TResult")
 

--- a/aqute/worker.py
+++ b/aqute/worker.py
@@ -8,7 +8,7 @@ from typing import Any, Generic
 
 from aqute.errors import AquteError, AquteTaskTimeoutError
 from aqute.ratelimiter import RateLimiter
-from aqute.task import END_MARKER, AquteTask, AquteTaskQueueType, TData, TResult
+from aqute.task import AquteTask, AquteTaskQueueType, TData, TResult
 
 logger = logging.getLogger("aqute.worker")
 
@@ -57,8 +57,6 @@ class Worker(Generic[TData, TResult]):
             self._counters.running += 1
             try:
                 logger.debug("Worker %s got task %s", self.name, task.task_id)
-                if task.data is END_MARKER:
-                    return
                 await self.handle_task(task)
             except asyncio.CancelledError as exc:
                 worker = asyncio.current_task()
@@ -214,6 +212,9 @@ class Foreman(Generic[TData, TResult]):
     async def add_task(self, task: AquteTask[TData, TResult]) -> None:
         """
         Adds a specified task to the input queue for processing.
+
+        Cancellation can race completed admission. A cancelled submission does
+        not prove that the task was not accepted or prevent its processing.
 
         Args:
             task: The task to be processed.

--- a/docs/http_client.md
+++ b/docs/http_client.md
@@ -4,7 +4,7 @@ Process independent GET requests with one shared HTTPX client and a fresh Aqute
 engine per run. The example combines four workers, an attempt-rate limiter,
 selected retries, and incremental result consumption.
 
-This recipe uses the 0.10.1 API for Python 3.11+. Follow the
+This recipe uses the 0.10.3 API for Python 3.11+. Follow the
 [installation instructions](index.md#installation).
 
 ## Use in an application

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,10 +17,10 @@ token-cost admission, shared throttling pauses, and checkpoints without a vendor
 
 ## Installation
 
-These pages and examples cover the 0.10.1 API. With Python 3.11+, install Aqute:
+These pages and examples cover the 0.10.3 API. With Python 3.11+, install Aqute:
 
 ```bash
-python -m pip install aqute==0.10.1
+python -m pip install aqute==0.10.3
 ```
 
 ## Choose an API
@@ -194,7 +194,7 @@ Install the optional HTTP client, then run this standalone example. It makes
 real GET requests; replace `urls` with your endpoints.
 
 ```bash
-python -m pip install aqute==0.10.1 httpx
+python -m pip install aqute==0.10.3 httpx
 ```
 
 Keep one client open around the managed result stream so workers finish cleanup

--- a/docs/llm_inference.md
+++ b/docs/llm_inference.md
@@ -8,7 +8,7 @@ it does not require a vendor SDK, credentials, or a running model server.
 ## Use in an application
 
 The checkout provides `httpx` in its development dependencies. To adapt the source
-outside the checkout, install `aqute==0.10.1` and `httpx`, and replace the endpoint,
+outside the checkout, install `aqute==0.10.3` and `httpx`, and replace the endpoint,
 model, credentials, and token estimates with your application's configuration.
 The source imports `RateLimitedError` and `retry_after_seconds` from
 `examples.http_client`; copy those definitions from the [HTTP source](http_client.md#runnable-source)

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1,6 +1,6 @@
 # API and rate limits
 
-This reference covers Aqute 0.10.2 and unreleased fixes for Python 3.11+.
+This reference covers Aqute 0.10.3 for Python 3.11+.
 For runnable workflows, start with [Choose an API](index.md#choose-an-api) and the [usage guide](usage.md).
 Import the engine with `from aqute import Aqute`.
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1,7 +1,7 @@
 # API and rate limits
 
-This reference covers Aqute 0.10.1 for Python 3.11+. For runnable workflows, start
-with [Choose an API](index.md#choose-an-api) and the [usage guide](usage.md).
+This reference covers Aqute 0.10.2 and unreleased fixes for Python 3.11+.
+For runnable workflows, start with [Choose an API](index.md#choose-an-api) and the [usage guide](usage.md).
 Import the engine with `from aqute import Aqute`.
 
 ## Constructor
@@ -18,9 +18,9 @@ input and output types; public methods preserve these types.
 | `result_queue` | `asyncio.Queue[AquteTask[TData, TResult]]` or `None` | `None` | Supplied result queue; its capacity also limits the internal result relay. Omission gives each capacity `workers_count`. |
 | `retry_count` | `int` | `0` | Extra attempts after the first handler call. |
 | `retry_delay` | `Callable[[int, Exception], float]` or `None` | `None` | Delay in seconds before a permitted retry; omission means zero delay. |
-| `specific_errors_to_retry` | Exception class, tuple of exception classes, or `None` | `None` | Eligible handler errors; `None` selects all caught handler errors while retry budget remains. |
+| `specific_errors_to_retry` | Exception class, tuple of exception classes, or `None` | `None` | Eligible handler errors; `None` selects all caught handler errors while retry budget remains; `()` selects none. |
 | `errors_to_not_retry` | Exception class, tuple of exception classes, or `None` | `None` | Excluded errors; takes precedence over the retry selection. |
-| `start_timeout_seconds` | `int`, `float`, or `None` | `None` | Limit on waiting for the first input after start; `None` disables the limit. |
+| `start_timeout_seconds` | `int`, `float`, or `None` | `None` | Limit on waiting for the first input after start; `None` disables the limit; prequeued inputs need no wait, even at zero or negative values. |
 | `input_task_queue_size` | `int` or `None` | `None` | Pending input capacity; `None` means `workers_count`, zero means unlimited. |
 | `use_priority_queue` | `bool` | `False` | Order admitted pending tasks by increasing `task_priority`. |
 | `task_timeout_seconds` | `int`, `float`, or `None` | `None` | Timeout per handler attempt, excluding limiter and retry waits; `None` disables it. |
@@ -152,6 +152,9 @@ For lower-level worker queues,
 `aqute.worker.Foreman` exposes `start()`, `add_task(AquteTask(...))`,
 `get_handled_task()`, `finalize()`, and `stop()`. Consume finite result queues while
 waiting for `finalize()`.
+
+Cancellation of `Foreman.add_task()` can race completed queue admission. It does
+not prove that the task was not accepted or prevent its processing.
 
 Inspect `error` and `result` on tasks returned directly by `Foreman`. It does not
 set `success`; `unwrap()` requires the engine's terminal success flag to return

--- a/docs/request_pool.md
+++ b/docs/request_pool.md
@@ -14,7 +14,7 @@ uv run --locked python -m examples.request_pool
 Install Aqute 0.10.1 or newer before using this recipe in an application:
 
 ```bash
-python -m pip install aqute==0.10.1
+python -m pip install aqute==0.10.3
 ```
 
 The released package includes the bounded-submission cancellation fix missing

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -2,7 +2,7 @@
 
 <span id="for-coding-agents"></span>
 
-This guide covers the 0.10.2 API and unreleased fixes for Python 3.11+. Start with
+This guide covers the 0.10.3 API for Python 3.11+. Start with
 [installation](index.md#installation) and [Choose an API](index.md#choose-an-api).
 See the [API reference](reference.md) for parameter types and defaults, or the
 [changelog](https://github.com/insomnes/aqute/blob/main/CHANGELOG.md) for migration
@@ -173,8 +173,11 @@ from aqute import AquteError, AquteTaskTimeoutError, AquteTooManyTasksFailedErro
 
 `start_timeout_seconds` limits waiting for the first input after start, including
 an asynchronous source's first item. Prequeued inputs do not wait, even at zero
-or negative values. An empty startup still expires; marking empty input complete
-with `finish()` or `finish_submitting()` requires no wait.
+or negative values. If the startup wait begins before any input arrives or
+completion is signalled, it remains subject to the timeout. Empty input requires
+no wait when `finish()` or `finish_submitting()` signals completion before that
+wait begins.
+
 `total_failed_tasks_limit` stops processing
 with `AquteTooManyTasksFailedError` when collected terminal failures reach the limit.
 The limit is inclusive: `total_failed_tasks_limit=1` stops on the first collected
@@ -182,7 +185,7 @@ terminal failure, after publishing that task's result. The background run task
 raises the error and cancels remaining workers; cancelled handlers do not produce
 terminal results.
 
-**Unreleased:** `finish()` and `iter_results()` raise `AquteError` if processing
+**Since 0.10.3:** `finish()` and `iter_results()` raise `AquteError` if processing
 is independently cancelled, for example by another caller invoking `stop()`.
 Cancellation of the consuming caller still propagates as `CancelledError`;
 an expired outer `asyncio.timeout` still raises `TimeoutError`, including during

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -2,7 +2,7 @@
 
 <span id="for-coding-agents"></span>
 
-This guide covers the 0.10.1 API for Python 3.11+. Start with
+This guide covers the 0.10.2 API and unreleased fixes for Python 3.11+. Start with
 [installation](index.md#installation) and [Choose an API](index.md#choose-an-api).
 See the [API reference](reference.md) for parameter types and defaults, or the
 [changelog](https://github.com/insomnes/aqute/blob/main/CHANGELOG.md) for migration
@@ -131,7 +131,7 @@ Handler exceptions derived from `Exception` become `AquteTask.error` values.
 `retry_count` specifies extra attempts; its default is zero.
 `specific_errors_to_retry` selects exception types.
 When omitted, it defaults to `None`: every caught handler error is eligible while
-the retry budget remains.
+the retry budget remains. An empty tuple, `()`, selects no errors.
 `errors_to_not_retry` excludes types and takes precedence when both filters match.
 
 `retry_delay(failed_attempt, error)` optionally returns finite, nonnegative seconds.
@@ -145,7 +145,7 @@ inside the worker `ExceptionGroup`. Callback errors and limiter failures also st
 the worker group and propagate; they are not handler error values. A retry can
 repeat a side effect, so applications must decide whether retrying is safe.
 
-**Unreleased:** If an awaited operation propagates `asyncio.CancelledError`
+**Since 0.10.2:** If an awaited operation propagates `asyncio.CancelledError`
 without a cancellation request on the worker, the run fails with an
 `ExceptionGroup` containing `AquteError`. For example, this occurs when a handler
 awaits an independently cancelled `asyncio.Future`. The cancelled work is not
@@ -158,7 +158,7 @@ by the caller keeps its existing behavior.
 negative timeout prevents handler invocation. Add `AquteTaskTimeoutError` to
 `errors_to_not_retry` when timeouts must not be retried.
 
-**Unreleased:** A handler-raised `TimeoutError` retains its original type and
+**Since 0.10.2:** A handler-raised `TimeoutError` retains its original type and
 message when the Aqute deadline has not expired, including when
 `task_timeout_seconds=None`. Retry filters now match that original exception.
 Previously, Aqute converted it to `AquteTaskTimeoutError`. Use `TimeoutError` in
@@ -172,12 +172,21 @@ from aqute import AquteError, AquteTaskTimeoutError, AquteTooManyTasksFailedErro
 ```
 
 `start_timeout_seconds` limits waiting for the first input after start, including
-an asynchronous source's first item. `total_failed_tasks_limit` stops processing
+an asynchronous source's first item. Prequeued inputs do not wait, even at zero
+or negative values. An empty startup still expires; marking empty input complete
+with `finish()` or `finish_submitting()` requires no wait.
+`total_failed_tasks_limit` stops processing
 with `AquteTooManyTasksFailedError` when collected terminal failures reach the limit.
 The limit is inclusive: `total_failed_tasks_limit=1` stops on the first collected
 terminal failure, after publishing that task's result. The background run task
 raises the error and cancels remaining workers; cancelled handlers do not produce
 terminal results.
+
+**Unreleased:** `finish()` and `iter_results()` raise `AquteError` if processing
+is independently cancelled, for example by another caller invoking `stop()`.
+Cancellation of the consuming caller still propagates as `CancelledError`;
+an expired outer `asyncio.timeout` still raises `TimeoutError`, including during
+cooperative cleanup.
 
 In the manual API, `finish()` propagates the run error. `get_result()` returns
 already-published results first, then propagates the error when the queue is empty
@@ -222,8 +231,13 @@ After start, a full input queue makes `add_task()` wait for capacity;
 it raises `AquteError` if the run completes normally before admission.
 Default capacity `workers_count` can therefore block service callers
 inside submission, so bound concurrent callers or apply an admission timeout.
+Cancellation or a timeout can race completed admission: it does not prove that
+the task was not accepted. Aqute counts accepted work even when the submitting
+caller is cancelled. Retrying a cancelled submission can duplicate processing;
+caller-supplied task IDs do not deduplicate work. The same admission ambiguity
+applies to `Foreman.add_task()`.
 
-**Unreleased:** Concurrent `add_task()` calls with omitted or empty IDs receive
+**Since 0.10.2:** Concurrent `add_task()` calls with omitted or empty IDs receive
 distinct generated IDs within one run, including while waiting for input capacity.
 Cancelled submissions can leave gaps. `stop()` resets the sequence, so later runs
 can reuse generated IDs. Caller-supplied IDs are not checked for duplicates or

--- a/tests/aqute/test_runtime_edges.py
+++ b/tests/aqute/test_runtime_edges.py
@@ -1,0 +1,218 @@
+import asyncio
+import contextlib
+
+import pytest
+
+from aqute import Aqute, AquteError
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("consumer", ["finish", "iterator"])
+@pytest.mark.parametrize("prior_cancellation", [False, True])
+async def test_independent_stop_fails_consumer_after_cleanup(
+    consumer, prior_cancellation
+):
+    """An independent stop raises AquteError, even after a caught cancellation."""
+    tasks_before = asyncio.all_tasks()
+    started = asyncio.Event()
+    cleaned = asyncio.Event()
+
+    async def handler(value: int) -> int:
+        started.set()
+        try:
+            await asyncio.Event().wait()
+            return value
+        finally:
+            await asyncio.sleep(0)
+            cleaned.set()
+
+    engine = Aqute(handler, 1)
+
+    async def consume():
+        if prior_cancellation:
+            caller = asyncio.current_task()
+            assert caller is not None
+            caller.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await asyncio.sleep(0)
+        if consumer == "finish":
+            await engine.add_task(1)
+            engine.start()
+            await engine.finish()
+        else:
+            async with engine.iter_results([1]) as results:
+                await anext(results)
+
+    operation = asyncio.create_task(consume())
+    try:
+        async with asyncio.timeout(1):
+            await started.wait()
+            await engine.stop()
+        done, _ = await asyncio.wait((operation,), timeout=1)
+        assert operation in done
+        with pytest.raises(AquteError, match="cancelled"):
+            await operation
+        assert cleaned.is_set()
+        assert asyncio.all_tasks() == tasks_before
+    finally:
+        operation.cancel()
+        with contextlib.suppress(asyncio.CancelledError, AquteError):
+            await operation
+        await engine.stop()
+
+
+@pytest.mark.asyncio
+async def test_iterator_observes_cancelled_load_after_last_result():
+    """Stopping after the last yield must raise AquteError on iterator completion."""
+
+    async def handler(value: int) -> int:
+        return value
+
+    engine = Aqute(handler, 1)
+    async with engine.iter_results([1]) as results:
+        assert (await anext(results)).unwrap() == 1
+        await engine.stop()
+        with pytest.raises(AquteError, match="cancelled"):
+            await anext(results)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("consumer", ["finish", "iterator"])
+@pytest.mark.parametrize("cancellation", ["cancel", "deadline"])
+async def test_consumer_cancellation_propagates_after_cleanup(consumer, cancellation):
+    """Caller cancellation and deadlines propagate after owned handler cleanup."""
+    tasks_before = asyncio.all_tasks()
+    started = asyncio.Event()
+    cleaning = asyncio.Event()
+    release = asyncio.Event()
+    cleaned = asyncio.Event()
+    deadline = asyncio.timeout(None)
+
+    async def handler(value: int) -> int:
+        started.set()
+        try:
+            await asyncio.Event().wait()
+            return value
+        finally:
+            cleaning.set()
+            await release.wait()
+            cleaned.set()
+
+    engine = Aqute(handler, 1)
+
+    async def consume():
+        async with deadline:
+            if consumer == "finish":
+                await engine.add_task(1)
+                engine.start()
+                await engine.finish()
+            else:
+                async with engine.iter_results([1]) as results:
+                    await anext(results)
+
+    operation = asyncio.create_task(consume())
+    try:
+        async with asyncio.timeout(1):
+            await started.wait()
+            if cancellation == "cancel":
+                operation.cancel()
+            else:
+                deadline.reschedule(asyncio.get_running_loop().time())
+            await cleaning.wait()
+            assert not operation.done()
+            release.set()
+        done, _ = await asyncio.wait((operation,), timeout=1)
+        assert operation in done
+        expected = asyncio.CancelledError if cancellation == "cancel" else TimeoutError
+        with pytest.raises(expected):
+            await operation
+        assert cleaned.is_set()
+        assert asyncio.all_tasks() == tasks_before
+    finally:
+        release.set()
+        operation.cancel()
+        with contextlib.suppress(asyncio.CancelledError, TimeoutError):
+            await operation
+        await engine.stop()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("start_timeout", [0, -1])
+async def test_prequeued_input_does_not_expire_startup(start_timeout):
+    """Prequeued input reaches the handler despite a nonpositive startup timeout."""
+
+    async def handler(value: int) -> int:
+        await asyncio.sleep(0)
+        return value + 1
+
+    engine = Aqute(handler, 1, start_timeout_seconds=start_timeout)
+    await engine.add_task(1)
+    try:
+        async with asyncio.timeout(1):
+            await engine.run()
+        assert [task.unwrap() for task in engine.drain_results()] == [2]
+    finally:
+        await engine.stop()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("start_timeout", [0, -1])
+async def test_empty_startup_still_expires(start_timeout):
+    """A nonpositive startup timeout fails when no input or completion is ready."""
+
+    async def handler(value: int) -> int:
+        return value
+
+    engine = Aqute(handler, 1, start_timeout_seconds=start_timeout)
+    load = engine.start()
+    try:
+        done, _ = await asyncio.wait((load,), timeout=1)
+        assert load in done
+        with pytest.raises(AquteError, match="Waited too long"):
+            await load
+    finally:
+        with contextlib.suppress(AquteError):
+            await engine.stop()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("start_timeout", [0, -1])
+async def test_finished_empty_input_needs_no_startup_wait(start_timeout):
+    """Completing intentionally empty input succeeds with a nonpositive timeout."""
+
+    async def handler(value: int) -> int:
+        return value
+
+    async with Aqute(handler, 1, start_timeout_seconds=start_timeout) as engine:
+        async with asyncio.timeout(1):
+            await engine.finish()
+        assert engine.drain_results() == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("selection", "exclusion", "expected_calls"),
+    [((), None, 1), (None, None, 3), ((ValueError,), ValueError, 1)],
+)
+async def test_retry_selection_respects_empty_tuple_and_exclusions(
+    selection, exclusion, expected_calls
+):
+    """Empty selection and exclusions prevent retries; None retains the budget."""
+    calls = 0
+
+    async def handler(_value: int) -> int:
+        nonlocal calls
+        calls += 1
+        raise ValueError("handler failed")
+
+    engine = Aqute(
+        handler,
+        1,
+        retry_count=2,
+        specific_errors_to_retry=selection,
+        errors_to_not_retry=exclusion,
+    )
+    (result,) = await engine.process_all([1])
+    assert calls == expected_calls
+    with pytest.raises(ValueError, match="handler failed"):
+        result.unwrap()

--- a/tests/worker/test_worker.py
+++ b/tests/worker/test_worker.py
@@ -1,10 +1,11 @@
 import asyncio
+import contextlib
 from typing import Any
 
 import pytest
 
 from aqute.errors import AquteTaskTimeoutError
-from aqute.task import END_MARKER, AquteTask, AquteTaskQueueType
+from aqute.task import AquteTask, AquteTaskQueueType
 from aqute.worker import Worker
 
 
@@ -58,31 +59,49 @@ async def test_worker_handle_task_error():
 
 
 @pytest.mark.asyncio
-async def test_handle_task_end():
+async def test_worker_processes_object_payload_and_cleans_up_on_cancellation():
+    """Object payloads reach the handler; cancellation awaits active task cleanup."""
     input_q: AquteTaskQueueType = asyncio.Queue()
     output_q: AquteTaskQueueType = asyncio.Queue()
+    started = asyncio.Event()
+    cleaned = asyncio.Event()
+    payload = object()
+
+    async def handler(data):
+        if data is payload:
+            return "handled object"
+        started.set()
+        try:
+            await asyncio.Event().wait()
+        finally:
+            await asyncio.sleep(0)
+            cleaned.set()
 
     worker = Worker(
         name="TestWorker",
-        handle_coro=simple_handler,
+        handle_coro=handler,
         input_q=input_q,
         output_q=output_q,
     )
-
     run_aiotask = asyncio.create_task(worker.run())
-
-    # Test that some object() do not stop us
-    task_with_object_data = AquteTask(object(), "pseudo-finish")
-    await worker.input_q.put(task_with_object_data)
-    out_task = await worker.output_q.get()
-    assert out_task is task_with_object_data
-
-    # And now we can check proper finish
-    finish_task = AquteTask(END_MARKER, "real-finish")
-    await worker.input_q.put(finish_task)
-    await run_aiotask
-    assert worker.output_q.empty()
-    assert worker.input_q.empty()
+    try:
+        async with asyncio.timeout(1):
+            await input_q.put(AquteTask(payload, "object"))
+            out_task = await output_q.get()
+            assert out_task.data is payload
+            assert out_task.result == "handled object"
+            await input_q.put(AquteTask("wait", "cancelled"))
+            await started.wait()
+            run_aiotask.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await run_aiotask
+            await input_q.join()
+        assert cleaned.is_set()
+        assert output_q.empty()
+    finally:
+        run_aiotask.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await run_aiotask
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Handle independent load cancellation consistently: `finish()` and result iteration report `AquteError` when processing stops independently, while caller cancellation and deadlines still propagate. Allow already-queued work with a nonpositive startup timeout, and treat an empty retry-selection tuple as selecting no errors.

Remove the unused worker shutdown sentinel. Clarify that submission cancellation can race accepted work and that result iteration owns consumption. Retry counters and repeated `start()`/`run()` behavior remain unchanged.
